### PR TITLE
[SUSPENDED] Additional RA cores script

### DIFF
--- a/emu-configs/additional_cores.cfg
+++ b/emu-configs/additional_cores.cfg
@@ -1,0 +1,1 @@
+atari800_libretro

--- a/emu-configs/additional_cores.cfg
+++ b/emu-configs/additional_cores.cfg
@@ -1,1 +1,3 @@
-atari800_libretro
+#remove this as comments may not be supported
+#Example
+#atari800_libretro

--- a/global.sh
+++ b/global.sh
@@ -8,6 +8,9 @@ emuconfigs="/app/retrodeck/emu-configs"                    # folder with all the
 lockfile="/var/config/retrodeck/.lock"                     # where the lockfile is located
 default_sd="/run/media/mmcblk0p1"                          # Steam Deck SD default path
 hard_version="$(cat '/app/retrodeck/version')"             # hardcoded version (in the readonly filesystem)
+ra_buildbot_path="http://buildbot.libretro.com/nightly/linux/x86_64/latest/" # Path to the RetroArch core direct downloads
+additional_cores_cfg="/app/retrodeck/emu-configs/additional_cores.cfg" # File for specifying additional cores to download which may not be part of the "stable" package
+additional_cores_tmp="/var/tmp/additional_cores" # Temporary directory for additional core downloads
 
 conf_write() {
   # writes the variables in the retrodeck config file

--- a/retrodeck.sh
+++ b/retrodeck.sh
@@ -190,6 +190,7 @@ ra_init() {
     dir_prep "$rdhome/.logs/retroarch" "/var/config/retroarch/logs"
     mkdir -pv /var/config/retroarch/cores/
     cp /app/share/libretro/cores/* /var/config/retroarch/cores/
+    grab_extra_ra_cores
     cp -fv $emuconfigs/retroarch.cfg /var/config/retroarch/
     cp -fv $emuconfigs/retroarch-core-options.cfg /var/config/retroarch/
     #rm -rf $rdhome/bios/bios # in some situations a double bios symlink is created
@@ -227,6 +228,39 @@ ra_init() {
     mv -rfv $rdhome/bios/MSX/Databases $rdhome/bios/Databases
     mv -rfv $rdhome/bios/MSX/Machines $rdhome/bios/Machines
     rm -rfv $rdhome/bios/MSX
+
+}
+
+# This will grab any cores that were not in the "stable" pack individually from the nightly repo. It will grab cores specified in the additional_cores.cfg file or, if that file is missing or empty, download all cores that are missing
+grab_extra_ra_cores() {
+  if [ -e $additional_cores_cfg ] && [ -n $additional_cores_cfg ] # Check if additional_cores.cfg exists and is not empty
+    then
+      readarray -t cores_wanted < $additional_cores_cfg
+    else # If additional_cores.cfg is empty, build array of all missing cores by comparing contents of cores and core info directories
+      all_cores=($(ls -1 --ignore="*example*" /app/share/libretro/info | sed -e 's/\.info$//'))
+      stable_cores=($(ls -1 /app/share/libretro/cores | sed -e 's/\.so$//'))
+      cores_wanted=()
+      for i in "${all_cores[@]}"; do
+          skip=
+          for j in "${stable_cores[@]}"; do
+              [[ $i == $j ]] && { skip=1; break; }
+          done
+          [[ -n $skip ]] || cores_wanted+=("$i")
+      done
+  fi
+
+  if [ ! -z $cores_wanted ] # Only act if cores are wanted
+    then
+    mkdir $additional_cores_tmp # Creat temp downloads directory (required for unzip)
+    for a in "${cores_wanted[@]}"; do # Download and unzip every core in the cores_wanted array
+      wget -nv $ra_buildbot_path$a.so.zip -O $additional_cores_tmp/$a.so.zip
+      unzip -u $additional_cores_tmp/$a.so.zip -d /var/config/retroarch/cores/
+      rm $additional_cores_tmp/$a.so.zip
+    done
+    rmdir $additional_cores_tmp # Cleanup temp downloads directory
+    else
+      echo "No additional cores required"
+  fi
 
 }
 


### PR DESCRIPTION
#124 This PR is a modular fix for this issue.

The atari800 core is not downloaded in the manifest because it does not exist in the latest version of the "stable" branch of libretro. To accommodate additional core requests in the future, this PR adds a function to download any additional missing cores during RA init, either by specifying them in a file, or if the file is missing/empty, determining all cores that are missing from the "stable" pack and downloading them from the nightly branch.

This PR is configured to download the missing atari800 core already, but is easy to add more to in the future through the new config file.