### PR TITLE
PCSX2-QT looking in the wrong place for saves

### DIFF
--- a/emu-configs/PCSX2/PCSX2.ini
+++ b/emu-configs/PCSX2/PCSX2.ini
@@ -21,13 +21,13 @@ SaveStateOnShutdown = true
 ConsoleToStdio = false
 HostFs = false
 PatchBios = false
-PatchRegion = 
+PatchRegion =
 BackupSavestate = true
 SavestateZstdCompression = true
 McdEnableEjection = true
 McdFolderAutoManage = true
 GzipIsoIndexTemplate = $(f).pindex.tmp
-BlockDumpSaveDirectory = 
+BlockDumpSaveDirectory =
 
 
 [EmuCore/Speedhacks]
@@ -169,7 +169,7 @@ ShadeBoost_Contrast = 50
 ShadeBoost_Saturation = 50
 saven = 0
 savel = 5000
-Adapter = 
+Adapter =
 shaderfx_conf = shaders/GS_FX_Settings.ini
 shaderfx_glsl = shaders/GS.fx
 
@@ -198,7 +198,7 @@ DplDecodingLevel = 0
 [DEV9/Eth]
 EthEnable = false
 EthApi = Unset
-EthDevice = 
+EthDevice =
 EthLogDNS = false
 InterceptDHCP = false
 PS2IP = 0.0.0.0
@@ -267,7 +267,7 @@ IOP.bitset = 0
 
 
 [Filenames]
-BIOS = 
+BIOS =
 
 
 [Framerate]
@@ -299,7 +299,7 @@ Multitap2_Slot4_Filename = Mcd-Multitap2-Slot04.ps2
 Bios = ~/retrodeck/bios
 Snapshots = ~/retrodeck/screenshots
 SaveStates = ~/retrodeck/states/ps2/pcsx2
-MemoryCards = ~/retrodeck/saves/ps2/pcsx2/memcards
+MemoryCards = ~/retrodeck/saves/ps2/memcards
 Logs = logs
 Cheats = cheats
 CheatsWS = cheats_ws


### PR DESCRIPTION
PCSX2-QT was set to look in the wrong location for saves after the 0.5.0 migration. Also removed some whitespace.