### PR TITLE
Plan for upcomfing SteamOS SD card path changes

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -29,10 +29,10 @@ browse() {
       fi
     else
       zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
-      --text="No directory selected. Do you want to return to the main menu?"
-      if [ $? == 1 ]
+      --text="No directory selected. Do you want to exit?"
+      if [ $? == 0 ]
       then
-        configurator_welcome_dialog
+        break
       fi
     fi
   done

--- a/global.sh
+++ b/global.sh
@@ -68,6 +68,12 @@ then
     fi
   fi
 
+  # Check if SD card path has changed from SteamOS update
+  if [[ ! -d $default_sd && "$(ls -A /run/media/deck/)" ]]; then
+    configurator_generic_dialog "The SD card was not found in the expected location.\nThis may happen when SteamOS is updated.\n\nPlease browse to the current location of the SD card.\n\nIf you are not using an SD card, please click \"Cancel\"."
+    default_sd=$(browse "SD Card Location")
+  fi
+
   rdhome="$HOME/retrodeck"                                   # the retrodeck home, aka ~/retrodeck
   roms_folder="$rdhome/roms"                                 # the default roms folder path
   saves_folder="$rdhome/saves"                               # the default saves folder path
@@ -97,4 +103,12 @@ else
   echo "Found RetroDECK config file in $rd_conf"
   echo "Loading it"
   source "$rd_conf"
+
+  # Update SD card path if changed from SteamOS update
+  if [[ ! -d $sdcard && "$(ls -A /run/media/deck/)" ]]; then
+    configurator_generic_dialog "The SD card was not found in the expected location.\nThis may happen when SteamOS is updated.\n\nPlease browse to the current location of the SD card.\n\nIf you are not using an SD card, please click \"Cancel\"."
+    sdcard=$(browse "SD Card Location")
+    conf_write
+    source "$rd_conf"
+  fi
 fi

--- a/global.sh
+++ b/global.sh
@@ -106,9 +106,11 @@ else
 
   # Update SD card path if changed from SteamOS update
   if [[ ! -d $sdcard && "$(ls -A /run/media/deck/)" ]]; then
+    prev_sd_path=$sdcard
     configurator_generic_dialog "The SD card was not found in the expected location.\nThis may happen when SteamOS is updated.\n\nPlease browse to the current location of the SD card.\n\nIf you are not using an SD card, please click \"Cancel\"."
-    sdcard=$(browse "SD Card Location")
-    conf_write
+    new_sd_path=$(browse "SD Card Location")
+    sed -i 's#'$prev_sd_path'#'$new_sd_path'#g' $rd_conf
     source "$rd_conf"
+    emulators_post_move
   fi
 fi

--- a/post_update.sh
+++ b/post_update.sh
@@ -7,7 +7,7 @@ post_update() {
 
   local prev_version=$(sed -e 's/[\.a-z]//g' <<< $version)
 
-  if [[ $prev_version -le "054" ]]; then
+  if [[ $prev_version -le "054" ]]; then # If updating from prior to save sorting change
 
     # Finding existing ROMs folder
     if [ -d "$default_sd/retrodeck" ]

--- a/retrodeck.sh
+++ b/retrodeck.sh
@@ -73,8 +73,8 @@ then
   # ...but the version doesn't match with the config file
   if [ "$hard_version" != "$version" ];
   then
-      echo "Config file's version is $version but the actual version is $hard_version"
-      post_update       # Executing post update script
+    echo "Config file's version is $version but the actual version is $hard_version"
+    post_update       # Executing post update script
   fi
 # Else, LOCKFILE IS NOT EXISTING (WAS REMOVED)
 # if the lock file doesn't exist at all means that it's a fresh install or a triggered reset
@@ -83,15 +83,11 @@ else
   finit             # Executing First/Force init
 fi
 
-# Normal Startup
-
-# Check if the retrodeck folder is existing
-if [ ! -d $rdhome ] then
-  zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
-  --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
-  --title "RetroDECK" \
-  --text="The retrodeck folder was not found on the previous location, please choose a new location.\nNOTE: the folder selection may work on desktop mode only."
-  configurator_destination_choice_dialog()
+# Check if SD card path has changed from SteamOS update
+if [[ ! -d $sd_card && "$(ls -A /run/media/deck/)" ]]; then
+  configurator_generic_dialog "The ROMs folder was not found in the expected location.\nThis may happen when SteamOS is updated.\n\nPlease browse to the current location of the "
 fi
+
+# Normal Startup
 
 start_retrodeck


### PR DESCRIPTION
Added some code to accommodate possible upcoming SD card path changes in SteamOS. If Valve implements a "seamless" solution where the existing path still exists (like a symlink of the old path to the new path) then everything should just keep working.