### PR TITLE
Cooker 0.6.1b fixes

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -565,6 +565,22 @@ dolphin_init() {
   dir_prep "$rdhome/saves/wii/dolphin" "/var/data/dolphin-emu/Wii"
 }
 
+primehack_init() {
+  echo "----------------------"
+  echo "Initializing Primehack"
+  echo "----------------------"
+  mkdir -pv /var/config/primehack/
+  cp -fvr "$emuconfigs/primehack/"* /var/config/primehack/
+  sed -i 's#~/retrodeck#'$rdhome'#g' /var/config/primehack/Dolphin.ini
+  dir_prep "$rdhome/saves/gc/primehack/EUR" "/var/data/primehack/GC/EUR"
+  dir_prep "$rdhome/saves/gc/primehack/USA" "/var/data/primehack/GC/USA"
+  dir_prep "$rdhome/saves/gc/primehack/JAP" "/var/data/primehack/GC/JAP"
+  dir_prep "$rdhome/screenshots" "/var/data/primehack/ScreenShots"
+  dir_prep "$rdhome/states" "/var/data/primehack/StateSaves"
+  mkdir -pv /var/data/primehack/Wii/
+  dir_prep "$rdhome/saves/wii/primehack" "/var/data/primehack/Wii"
+}
+
 pcsx2_init() {
   echo "----------------------"
   echo "Initializing PCSX2"
@@ -670,17 +686,17 @@ standalones_init() {
   echo "------------------------------------"
   echo "Initializing standalone emulators"
   echo "------------------------------------"
-
-  yuzu_init
   citra_init
   dolphin_init
+  duckstation_init
   melonds_init
   pcsx2_init
   ppssppsdl_init
+  primehack_init
   rpcs3_init
-  xemu_init
-  duckstation_init
   ryujinx_init
+  xemu_init
+  yuzu_init
 }
 
 emulators_post_move() {
@@ -712,6 +728,15 @@ emulators_post_move() {
   dir_prep "$rdhome/screenshots" "/var/data/dolphin-emu/ScreenShots"
   dir_prep "$rdhome/states" "/var/data/dolphin-emu/StateSaves"
   dir_prep "$rdhome/saves/wii/dolphin" "/var/data/dolphin-emu/Wii/"
+
+  # Primehack section
+  sed -i 's#~/retrodeck#'$rdhome'#g' /var/config/primehack/Dolphin.ini
+  dir_prep "$rdhome/saves/gc/primehack/EUR" "/var/data/primehack/GC/EUR"
+  dir_prep "$rdhome/saves/gc/primehack/USA" "/var/data/primehack/GC/USA"
+  dir_prep "$rdhome/saves/gc/primehack/JAP" "/var/data/primehack/GC/JAP"
+  dir_prep "$rdhome/screenshots" "/var/data/primehack/ScreenShots"
+  dir_prep "$rdhome/states" "/var/data/primehack/StateSaves"
+  dir_prep "$rdhome/saves/wii/primehack" "/var/data/primehack/Wii/"
 
   # PCSX2 section
   sed -i 's#~/retrodeck#'$rdhome'#g' /var/config/PCSX2/inis/PCSX2_ui.ini

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -23,16 +23,17 @@ source /app/libexec/functions.sh # uncomment for flatpak testing
 #     - Reset RetroDECK
 #       - Reset RetroArch
 #       - Reset Specific Standalone Emulator
-#           - Reset Yuzu
-#           - Reset Dolphin
-#           - Reset PCSX2
-#           - Reset MelonDS
 #           - Reset Citra
+#           - Reset Dolphin
+#           - Reset Duckstation
+#           - Reset MelonDS
+#           - Reset PCSX2
+#           - Reset PPSSPP
+#           - Reset Primehack
 #           - Reset RPCS3
 #           - Reset Ryujinx
 #           - Reset XEMU
-#           - Reset PPSSPP
-#           - Reset Duckstation
+#           - Reset Yuzu
 #       - Reset All Standalone Emulators
 #       - Reset Tools
 #       - Reset All
@@ -72,6 +73,7 @@ configurator_reset_dialog() {
     "MelonDS" \
     "PCSX2" \
     "PPSSPP" \
+    "Primehack" \
     "RPCS3" \
     "Ryujinx" \
     "XEMU" \
@@ -111,6 +113,11 @@ configurator_reset_dialog() {
 
     "PPSSPP" )
       ppssppsdl_init
+      configurator_process_complete_dialog "resetting $emulator_to_reset"
+    ;;
+
+    "Primehack" )
+      primehack_init
       configurator_process_complete_dialog "resetting $emulator_to_reset"
     ;;
 
@@ -216,6 +223,7 @@ configurator_power_user_changes_dialog() {
     "PCSX2-QT" \
     "PCSX2-Legacy" \
     "PPSSPP" \
+    "Primehack" \
     "RPCS3" \
     "Ryujinx" \
     "XEMU" \
@@ -253,6 +261,10 @@ configurator_power_user_changes_dialog() {
 
     "PPSSPP" )
       PPSSPPSDL
+    ;;
+
+    "Primehack" )
+      primehack-wrapper
     ;;
 
     "RPCS3" )

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -417,7 +417,7 @@ configurator_move_dialog() {
             fi
 
             if [[ ! -L "$HOME/retrodeck" ]]; then # Always link back to original directory
-              ln -svf "$sdcard/retrodeck" "$HOME/retrodeck"
+              ln -svf "$sdcard/retrodeck" "$HOME"
             fi
 
             rdhome="$sdcard/retrodeck"
@@ -466,7 +466,7 @@ configurator_move_dialog() {
           fi
 
           if [[ ! -L "$HOME/retrodeck" ]]; then
-            ln -svf "$custom_dest/retrodeck" "$HOME/retrodeck"
+            ln -svf "$custom_dest/retrodeck" "$HOME"
           fi
 
           rdhome="$custom_dest/retrodeck"


### PR DESCRIPTION
This fixes an issue where the ~/retrodeck symlink was not created properly when migrating the RetroDECK data folder to a new location.