### PR TITLE
Add CLI option to run Configurator directly

### DIFF
--- a/retrodeck.sh
+++ b/retrodeck.sh
@@ -57,6 +57,10 @@ https://retrodeck.net
       rm -f "$lockfile"
       shift # past argument with no value
       ;;
+    --configure*)
+      sh /var/config/retrodeck/tools/configurator.sh
+      shift # past argument with no value
+      ;;
     -*|--*)
       echo "Unknown option $i"
       exit 1

--- a/retrodeck.sh
+++ b/retrodeck.sh
@@ -17,9 +17,10 @@ Arguments:
     -h, --help        Print this help
     -v, --version     Print RetroDECK version
     --info-msg        Print paths and config informations
+    --configure       Starts the RetroDECK Configurator
     --reset-all       Starts the initial RetroDECK installer (backup your data first!)
     --reset-ra        Resets RetroArch's config to the default values
-    --reset-sa        Reset standalone emulator configs to the default values
+    --reset-sa        Reset all standalone emulator configs to the default values
     --reset-tools     Recreate the tools section
 
 For flatpak run specific options please run: flatpak run -h


### PR DESCRIPTION
This adds an option to run the Configurator utility directly from the CLI, which will help mitigate the window focus issues that happen in Desktop mode on the Steam Deck.