### PR TITLE
es_systems.xml: Add company names for Vectrex, ColecoVision and Atomiswave

### DIFF
--- a/es-configs/es_systems.xml
+++ b/es-configs/es_systems.xml
@@ -231,7 +231,7 @@
     </system>
     <system>
         <name>atomiswave</name>
-        <fullname>Atomiswave</fullname>
+        <fullname>Sammy Atomiswave</fullname>
         <path>%ROMPATH%/atomiswave</path>
         <extension>.cdi .CDI .iso .ISO .elf .ELF .bin .BIN .cue .CUE .gdi .GDI .lst .LST .dat .DAT .m3u .M3U .7z .7Z .zip .ZIP</extension>
         <command label="Flycast">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/flycast_libretro.so %ROM%</command>
@@ -322,7 +322,7 @@
 -->
     <system>
         <name>colecovision</name>
-        <fullname>ColecoVision</fullname>
+        <fullname>Coleco ColecoVision</fullname>
         <path>%ROMPATH%/colecovision</path>
         <extension>.bin .BIN .cas .CAS .col .COL .cv .CV .dsk .DSK .m3u .M3U .mx1 .MX1 .mx2 .MX2 .ri .RI .rom .ROM .sc .SC .sg .SG .7z .7Z .zip .ZIP</extension>
         <command label="blueMSX">%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/bluemsx_libretro.so %ROM%</command>
@@ -1472,7 +1472,7 @@
     </system>
     <system>
         <name>vectrex</name>
-        <fullname>Vectrex</fullname>
+        <fullname>GCE Vectrex</fullname>
         <path>%ROMPATH%/vectrex</path>
         <extension>.bin .BIN .vec .VEC .gam .GAM .vc .VC .7z .7Z .zip .ZIP</extension>
         <command>%EMULATOR_RETROARCH% -L %CORE_RETROARCH%/vecx_libretro.so %ROM%</command>


### PR DESCRIPTION
Add company names for Vectrex, ColecoVision and Atomiswave in the `<fullname>` field for consitency.

Note: A few other entries don't have a company name listed and I didn't make a change because they were shared by a few entities, i.e. 3DO (developed by the "3DO Corp 3DO" would sound weird, and several manufacturers existed), the MSX computers were various companies jointly developed by Microsoft, etc.