### PR TITLE
Duckstation config location fix

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -671,9 +671,9 @@ duckstation_init() {
   echo "------------------------"
   echo "Initializing DUCKSTATION"
   echo "------------------------"
-  mkdir -p /var/config/duckstation/
-  cp -fv $emuconfigs/duckstation/* /var/config/duckstation
-  sed -i 's#/home/deck/retrodeck/bios#'$rdhome/bios'#g' /var/config/duckstation/settings.ini
+  mkdir -p /var/data/duckstation/
+  cp -fv $emuconfigs/duckstation/* /var/data/duckstation
+  sed -i 's#/home/deck/retrodeck/bios#'$rdhome/bios'#g' /var/data/duckstation/settings.ini
 }
 
 ryujinx_init() {
@@ -824,7 +824,7 @@ emulators_post_move() {
   sed -i 's#/home/deck/retrodeck#'$rdhome'#g' /var/config/ppsspp/PSP/SYSTEM/ppsspp.ini
 
   # Duckstation section
-  sed -i 's#/home/deck/retrodeck/bios#'$rdhome/bios'#g' /var/config/duckstation/settings.ini
+  sed -i 's#/home/deck/retrodeck/bios#'$rdhome/bios'#g' /var/data/duckstation/settings.ini
 
   # Ryujinx section
   sed -i 's#/home/deck/retrodeck#'$rdhome'#g' /var/config/Ryujinx/Config.json

--- a/global.sh
+++ b/global.sh
@@ -14,6 +14,7 @@ hard_version="$(cat '/app/retrodeck/version')"             # hardcoded version (
 # Config files for emulators with single config files
 
 citraconf="/var/config/citra-emu/qt-config.ini"
+duckstationconf="/var/data/duckstation/settings.ini"
 melondsconf="/var/config/melonDS/melonDS.ini"
 rpcs3conf="/var/config/rpcs3/config.yml"
 yuzuconf="/var/config/yuzu/qt-config.ini"


### PR DESCRIPTION
Duckstation is looking for its config file in /var/data/duckstation, not /var/config/duckstation, so the shipped config file was not being read properly.