### PR TITLE
Cooker 0.6.3b icenine451

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -868,7 +868,7 @@ xemu_init() {
   echo "------------------------"
   mkdir -pv $rdhome/saves/xbox/xemu/
   # removing config directory to wipe legacy files
-  rm -rf /var/config/xemu
+  rm -rf /var/data/xemu
   mkdir -pv /var/data/xemu/
   cp -fv $emuconfigs/xemu.toml /var/data/xemu/xemu.toml
   sed -i 's#/home/deck/retrodeck#'$rdhome'#g' /var/data/xemu/xemu.toml

--- a/functions.sh
+++ b/functions.sh
@@ -868,10 +868,11 @@ xemu_init() {
   echo "------------------------"
   mkdir -pv $rdhome/saves/xbox/xemu/
   # removing config directory to wipe legacy files
+  rm -rf /var/config/xemu
   rm -rf /var/data/xemu
-  mkdir -pv /var/data/xemu/
-  cp -fv $emuconfigs/xemu.toml /var/data/xemu/xemu.toml
-  sed -i 's#/home/deck/retrodeck#'$rdhome'#g' /var/data/xemu/xemu.toml
+  dir_prep "/var/config/xemu" "/var/data/xemu" # Creating config folder in /var/config for consistentcy and linking back to original location where emulator will look
+  cp -fv $emuconfigs/xemu.toml /var/config/xemu/xemu.toml
+  sed -i 's#/home/deck/retrodeck#'$rdhome'#g' /var/config/xemu/xemu.toml
   # Preparing HD dummy Image if the image is not found
   if [ ! -f $rdhome/bios/xbox_hdd.qcow2 ]
   then

--- a/post_update.sh
+++ b/post_update.sh
@@ -203,12 +203,18 @@ post_update() {
     # In version 0.6.2b, the following changes were made that required config file updates/reset:
     # - Put Dolphin and Primehack save states in different folders inside $rd_home/states
     # - Fix symlink to hard-coded PICO-8 config folder (dir_prep doesn't like ~)
+    # - Overwrite Citra and Yuzu configs, as controller mapping was broken due to emulator updates.
     
     dir_prep "$rdhome/states/dolphin" "/var/data/dolphin-emu/StateSaves"
     dir_prep "$rdhome/states/primehack" "/var/data/primehack/StateSaves"
 
     rm -rf "$HOME/~/" # Remove old incorrect location from 0.6.2b
     dir_prep "$bios_folder/pico-8" "$HOME/.lexaloffle/pico-8" # Store binary and config files together. The .lexaloffle directory is a hard-coded location for the PICO-8 config file, cannot be changed
+
+    cp -fv $emuconfigs/citra/qt-config.ini /var/config/citra-emu/qt-config.ini
+    sed -i 's#~/retrodeck#'$rdhome'#g' /var/config/citra-emu/qt-config.ini
+    cp -fvr $emuconfigs/yuzu/* /var/config/yuzu/
+    sed -i 's#~/retrodeck#'$rdhome'#g' /var/config/yuzu/qt-config.ini
   fi
 
   # The following commands are run every time.


### PR DESCRIPTION
- Added overwriting Citra/Yuzu configs on update to 0.6.3, as previous controller mapping was broken due to emulator update.
- Fixed Xemu init function