### PR TITLE
Cooker-0.6.3b-icenine451 3/22/23

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1033,15 +1033,6 @@ cli_emulator_reset() {
   esac
 }
 
-tools_init() {
-  rm -rfv /var/config/retrodeck/tools/
-  mkdir -pv /var/config/retrodeck/tools/
-  cp -rfv /app/retrodeck/tools/* /var/config/retrodeck/tools/
-  mkdir -pv /var/config/emulationstation/.emulationstation/custom_systems/tools/
-  rm -rfv /var/config/retrodeck/tools/gamelist.xml
-  cp -fv /app/retrodeck/tools-gamelist.xml /var/config/retrodeck/tools/gamelist.xml
-}
-
 emulators_post_move() {
   # This script will redo the symlinks for all emulators after moving the $rdhome location without resetting other options
   # FUTURE WORK: The sed commands here should be replaced with set_setting_value and dir_prep should be replaced with changing paths in config files directly where possible
@@ -1321,7 +1312,6 @@ finit() {
   (
   ra_init
   standalones_init
-  tools_init
   ) |
   zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \

--- a/net.retrodeck.retrodeck.yml
+++ b/net.retrodeck.retrodeck.yml
@@ -1069,7 +1069,7 @@ modules:
       - mkdir -p /app/tools
       - cp tools/configurator.sh /app/tools/configurator.sh
       - chmod +x /app/tools/configurator.sh
-      - cp es-configs/tools-gamelist.xml /app/tools/tools-gamelist.xml
+      - cp es-configs/tools-gamelist.xml /app/tools/gamelist.xml
 
       # Function libraries
       - mkdir -p /app/libexec

--- a/post_update.sh
+++ b/post_update.sh
@@ -209,6 +209,7 @@ post_update() {
     dir_prep "$rdhome/states/primehack" "/var/data/primehack/StateSaves"
 
     rm -rf "$HOME/~/" # Remove old incorrect location from 0.6.2b
+    rm -f "$HOME/.lexaloffle/pico-8" # Remove old symlink to prevent recursion
     dir_prep "$bios_folder/pico-8" "$HOME/.lexaloffle/pico-8" # Store binary and config files together. The .lexaloffle directory is a hard-coded location for the PICO-8 config file, cannot be changed
 
     cp -fv $emuconfigs/citra/qt-config.ini /var/config/citra-emu/qt-config.ini
@@ -219,7 +220,6 @@ post_update() {
 
   # The following commands are run every time.
 
-  tools_init
   update_rd_conf
   ) |
   zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \

--- a/retrodeck.sh
+++ b/retrodeck.sh
@@ -20,7 +20,6 @@ Arguments:
     --configurator                Starts the RetroDECK Configurator
     --compress <file>             Compresses target file to .chd format. Supports .cue, .iso and .gdi formats
     --reset-emulator <emulator>   Reset one or more emulator configs to the default values
-    --reset-tools                 Reset the RetroDECK Tools section
     --reset-retrodeck             Starts the initial RetroDECK installer (backup your data first!)
 
 For flatpak run specific options please run: flatpak run -h
@@ -64,18 +63,6 @@ https://retrodeck.net
         fi
       else
         echo "$emulator is not a valid selection, exiting..."
-        exit
-      fi
-      ;;
-    --reset-tools*)
-      echo "You are about to reset the RetroDECK tools."
-      read -p "Enter 'y' to continue, 'n' to stop: " response
-      if [[ $response == [yY] ]]; then
-        tools_init
-        read -p "The process has been completed, press Enter key to start RetroDECK."
-        shift # Continue launch after previous command is finished
-      else
-        read -p "The process has been cancelled, press Enter key to exit."
         exit
       fi
       ;;

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -50,7 +50,6 @@ source /app/libexec/functions.sh
 #           - Reset XEMU
 #           - Reset Yuzu
 #       - Reset All Emulators
-#       - Reset Tools
 #       - Reset All
 
 # Code for the menus should be put in reverse order, so functions for sub-menus exists before it is called by the parent menu
@@ -63,7 +62,6 @@ configurator_reset_dialog() {
   --column="Choice" --column="Action" \
   "Reset Specific Emulator" "Reset only one specific emulator to default settings" \
   "Reset All Emulators" "Reset all emulators to default settings" \
-  "Reset Tools" "Reset Tools menu entries" \
   "Reset All" "Reset RetroDECK to default settings" )
 
   case $choice in
@@ -154,11 +152,6 @@ configurator_reset_dialog() {
   ra_init
   standalones_init
   configurator_process_complete_dialog "resetting all emulators"
-;;
-
-"Reset Tools" )
-  tools_init
-  configurator_process_complete_dialog "resetting the tools menu"
 ;;
 
 "Reset All" )
@@ -558,11 +551,11 @@ configurator_check_bios_files_basic() {
   do
     bios_file_found="No"
     bios_hash_matched="No"
-    if [[ -f "$bios_dir/$bios_subdir$bios_file" ]]; then
+    if [[ -f "$bios_folder/$bios_subdir$bios_file" ]]; then
       bios_file_found="Yes"
       if [[ $bios_hash == "Unknown" ]]; then
         bios_hash_matched="Unknown"
-      elif [[ $(md5sum "$bios_dir/$bios_subdir$bios_file" | awk '{ print $1 }') == "$bios_hash" ]]; then
+      elif [[ $(md5sum "$bios_folder/$bios_subdir$bios_file" | awk '{ print $1 }') == "$bios_hash" ]]; then
         bios_hash_matched="Yes"
       fi
     fi
@@ -585,11 +578,11 @@ configurator_check_bios_files_advanced() {
   do
     bios_file_found="No"
     bios_hash_matched="No"
-    if [[ -f "$bios_dir/$bios_subdir$bios_file" ]]; then
+    if [[ -f "$bios_folder/$bios_subdir$bios_file" ]]; then
       bios_file_found="Yes"
       if [[ $bios_hash == "Unknown" ]]; then
         bios_hash_matched="Unknown"
-      elif [[ $(md5sum "$bios_dir/$bios_subdir$bios_file" | awk '{ print $1 }') == "$bios_hash" ]]; then
+      elif [[ $(md5sum "$bios_folder/$bios_subdir$bios_file" | awk '{ print $1 }') == "$bios_hash" ]]; then
         bios_hash_matched="Yes"
       fi
     fi


### PR DESCRIPTION
- Removed "reset tools" options as those are now in RO space
- Fixed recursive symlink possibility for pico-8 setup
- Fixed BIOS check tool variable name
- Fixed tools gamelist dest file name