### PR TITLE
Cooker 0.6.3b icenine451

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -1312,7 +1312,7 @@ finit() {
   # PICO-8
   dir_prep "$bios_folder/pico-8" "$HOME/.lexaloffle/pico-8" # Store binary and config files together. The .lexaloffle directory is a hard-coded location for the PICO-8 config file, cannot be changed
   dir_prep "$roms_folder/pico8" "$bios_folder/pico-8/carts" # Symlink default game location to RD roms for cleanliness (this location is overridden anyway by the --root_path launch argument anyway)
-  dir_prep "$bios_folder/pico-8/cdata" "$saves_folder/pico-8" # PICO-8 saves folder
+  dir_prep "$saves_folder/pico-8" "$bios_folder/pico-8/cdata"  # PICO-8 saves folder
 
   (
   ra_init

--- a/functions.sh
+++ b/functions.sh
@@ -705,6 +705,13 @@ dir_prep() {
 
   echo -e "\n[DIR PREP]\nMoving $symlink in $real" #DEBUG
 
+   # if the symlink dir is already a symlink, unlink it first, to prevent recursion
+  if [ -L "$symlink" ];
+  then
+    echo "$symlink is already a symlink, unlinking to prevent recursives" #DEBUG
+    unlink "$symlink"
+  fi
+
   # if the dest dir exists we want to backup it
   if [ -d "$symlink" ];
   then
@@ -715,6 +722,7 @@ dir_prep() {
   # if the real dir is already a symlink, unlink it first
   if [ -L "$real" ];
   then
+    echo "$real is already a symlink, unlinking to prevent recursives" #DEBUG
     unlink "$real"
   fi
 

--- a/functions.sh
+++ b/functions.sh
@@ -1278,14 +1278,11 @@ finit() {
 
   # Recreating the folder
   rm -rfv /var/config/emulationstation/
-  rm -rfv /var/config/retrodeck/tools/
   mkdir -pv /var/config/emulationstation/
 
   # Initializing ES-DE
   # TODO: after the next update of ES-DE this will not be needed - let's test it
   emulationstation --home /var/config/emulationstation --create-system-dirs
-
-  mkdir -pv /var/config/retrodeck/tools/
 
   #zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --text="RetroDECK will now install the needed files.\nPlease wait up to one minute,\nanother message will notify when the process will be finished.\n\nPress OK to continue."
 

--- a/post_update.sh
+++ b/post_update.sh
@@ -211,6 +211,7 @@ post_update() {
     rm -rf "$HOME/~/" # Remove old incorrect location from 0.6.2b
     rm -f "$HOME/.lexaloffle/pico-8" # Remove old symlink to prevent recursion
     dir_prep "$bios_folder/pico-8" "$HOME/.lexaloffle/pico-8" # Store binary and config files together. The .lexaloffle directory is a hard-coded location for the PICO-8 config file, cannot be changed
+    dir_prep "$saves_folder/pico-8" "$bios_folder/pico-8/cdata" # PICO-8 saves folder structure was backwards, fixing for consistency.
 
     cp -fv $emuconfigs/citra/qt-config.ini /var/config/citra-emu/qt-config.ini
     sed -i 's#RETRODECKHOMEDIR#'$rdhome'#g' /var/config/citra-emu/qt-config.ini

--- a/post_update.sh
+++ b/post_update.sh
@@ -216,6 +216,9 @@ post_update() {
     sed -i 's#RETRODECKHOMEDIR#'$rdhome'#g' /var/config/citra-emu/qt-config.ini
     cp -fvr $emuconfigs/yuzu/* /var/config/yuzu/
     sed -i 's#RETRODECKHOMEDIR#'$rdhome'#g' /var/config/yuzu/qt-config.ini
+
+    # Remove unneeded tools folder, as location has changed to RO space
+    rm -rfv /var/config/retrodeck/tools/
   fi
 
   # The following commands are run every time.


### PR DESCRIPTION
- Fixed a bug in dir_prep that could cause recursive symlinks if symlink destination already existed.
- Fixed the backwards structure for PICO-8 saves
- Removing unneeded /var/config/retrodeck/tools folder, now that the Configurator is in RO space.