### PR TITLE
Cooker 0.7.0b icenine451

### DIFF
--- a/emu-configs/defaults/retrodeck/presets/PCSX2_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/PCSX2_presets.cfg
@@ -1,5 +1,5 @@
 config_file_format^pcsx2
-target_file^$pcsx2qtconf
+target_file^$pcsx2conf
 defaults_file^$emuconfigs/PCSX2/PCSX2.ini
 change^cheevos^Enabled^true^Achievements
 change^cheevos^Username^$cheevos_username^Achievements

--- a/emu-configs/defaults/retrodeck/presets/SNES_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/SNES_presets.cfg
@@ -1,10 +1,6 @@
 config_file_format^retroarch
 target_file^/var/config/retroarch/config/Snes9x/snes.cfg
 defaults_file^$emuconfigs/retroarch/retroarch.cfg
-change^cheevos^cheevos_enable^true
-change^cheevos^cheevos_token^$cheevos_token
-change^cheevos^cheevos_username^$cheevos_username
-change^cheevos_hardcore^cheevos_hardcore_mode_enable^true
 change^borders^input_overlay^/var/config/retroarch/overlays/borders/pegasus/snes87.cfg
 change^borders^input_overlay_aspect_adjust_landscape^0.305000
 change^borders^input_overlay_scale_landscape^1.050000

--- a/emu-configs/defaults/retrodeck/presets/gb_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/gb_presets.cfg
@@ -1,0 +1,14 @@
+config_file_format^retroarch
+target_file^/var/config/retroarch/config/Gambatte/gb.cfg
+defaults_file^$emuconfigs/retroarch/retroarch.cfg
+change^borders^aspect_ratio_index^23
+change^borders^custom_viewport_height^576
+change^borders^custom_viewport_width^640
+change^borders^custom_viewport_x^320
+change^borders^custom_viewport_y^20
+change^borders^input_overlay^/var/config/retroarch/overlays/borders/pegasus/gb.cfg
+change^borders^input_overlay_aspect_adjust_landscape^0.110000
+change^borders^input_overlay_enable^true
+change^borders^input_overlay_scale_landscape^1.205000
+change^borders^input_overlay_y_offset_landscape^0.005000
+enable^nintendo_button_layout^/var/config/retroarch/config/remaps/Gambatte/gb.rmp

--- a/emu-configs/defaults/retrodeck/presets/gba_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/gba_presets.cfg
@@ -1,0 +1,13 @@
+config_file_format^retroarch
+target_file^/var/config/retroarch/config/mGBA/gba.cfg
+defaults_file^$emuconfigs/retroarch/retroarch.cfg
+change^borders^aspect_ratio_index^23
+change^borders^custom_viewport_height^600
+change^borders^custom_viewport_width^900
+change^borders^custom_viewport_x^190
+change^borders^custom_viewport_y^37
+change^borders^input_overlay^/var/config/retroarch/overlays/borders/pegasus/gba.cfg
+change^borders^input_overlay_aspect_adjust_landscape^0.105000
+change^borders^input_overlay_enable^true
+change^borders^input_overlay_scale_landscape^1.140000
+enable^nintendo_button_layout^/var/config/retroarch/config/remaps/Gambatte/gbc.rmp

--- a/emu-configs/defaults/retrodeck/presets/gbc_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/gbc_presets.cfg
@@ -1,0 +1,14 @@
+config_file_format^retroarch
+target_file^/var/config/retroarch/config/Gambatte/gbc.cfg
+defaults_file^$emuconfigs/retroarch/retroarch.cfg
+change^borders^aspect_ratio_index^23
+change^borders^custom_viewport_height^576
+change^borders^custom_viewport_width^640
+change^borders^custom_viewport_x^320
+change^borders^custom_viewport_y^20
+change^borders^input_overlay^/var/config/retroarch/overlays/borders/pegasus/gbc.cfg
+change^borders^input_overlay_aspect_adjust_landscape^0.110000
+change^borders^input_overlay_enable^true
+change^borders^input_overlay_scale_landscape^1.205000
+change^borders^input_overlay_y_offset_landscape^0.005000
+enable^nintendo_button_layout^/var/config/retroarch/config/remaps/Gambatte/gbc.rmp

--- a/emu-configs/defaults/retrodeck/presets/genesis_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/genesis_presets.cfg
@@ -1,0 +1,8 @@
+config_file_format^retroarch
+target_file^/var/config/retroarch/config/Genesis Plus GX/genesis.cfg
+defaults_file^$emuconfigs/retroarch/retroarch.cfg
+change^borders^input_overlay^input_overlay^/var/config/retroarch/overlays/borders/pegasus/genesis.cfg
+change^borders^input_overlay_aspect_adjust_landscape^0.100000
+change^borders^input_overlay_enable^true
+change^borders^input_overlay_scale_landscape^1.040000
+change^widescreen^aspect_ratio_index^24

--- a/emu-configs/defaults/retrodeck/presets/gg_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/gg_presets.cfg
@@ -1,0 +1,11 @@
+config_file_format^retroarch
+target_file^/var/config/retroarch/config/Genesis Plus GX/gg.cfg
+defaults_file^$emuconfigs/retroarch/retroarch.cfg
+change^borders^input_overlay^aspect_ratio_index^23
+change^borders^custom_viewport_width^800
+change^borders^custom_viewport_x^240
+change^borders^custom_viewport_y^43
+change^borders^input_overlay^/var/config/retroarch/overlays/borders/pegasus/gg.cfg
+change^borders^input_overlay_aspect_adjust_landscape^-0.080000
+change^borders^input_overlay_enable^true
+change^borders^input_overlay_scale_landscape^1.345000

--- a/emu-configs/defaults/retrodeck/presets/n64_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/n64_presets.cfg
@@ -1,0 +1,8 @@
+config_file_format^retroarch
+target_file^/var/config/retroarch/config/Mupen64Plus-Next/n64.cfg
+defaults_file^$emuconfigs/retroarch/retroarch.cfg
+change^borders^input_overlay^/var/config/retroarch/overlays/borders/pegasus/N64.cfg
+change^borders^input_overlay_aspect_adjust_landscape^0.145000
+change^borders^input_overlay_enable^true
+change^widescreen^aspect_ratio_index^24
+enable^nintendo_button_layout^/var/config/retroarch/config/remaps/Snes9x/snes.rmp

--- a/emu-configs/defaults/retrodeck/presets/psx_ra_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/psx_ra_presets.cfg
@@ -1,0 +1,8 @@
+config_file_format^retroarch
+target_file^/var/config/retroarch/config/SwanStation/psx.cfg
+defaults_file^$emuconfigs/retroarch/retroarch.cfg
+change^borders^input_overlay^/var/config/retrodeck/overlays/borders/pegasus/psx.cfg
+change^borders^input_overlay_aspect_adjust_landscape^0.120000
+change^borders^input_overlay_enable^true
+change^borders^input_overlay_scale_landscape^1.040000
+change^widescreen^aspect_ratio_index^24

--- a/emu-configs/defaults/retrodeck/presets/remaps/Gambatte/gb.rmp.disabled
+++ b/emu-configs/defaults/retrodeck/presets/remaps/Gambatte/gb.rmp.disabled
@@ -1,0 +1,4 @@
+input_player1_btn_a = "0"
+input_player1_btn_b = "8"
+input_player1_btn_x = "1"
+input_player1_btn_y = "9"

--- a/emu-configs/defaults/retrodeck/presets/remaps/Gambatte/gbc.rmp.disabled
+++ b/emu-configs/defaults/retrodeck/presets/remaps/Gambatte/gbc.rmp.disabled
@@ -1,0 +1,4 @@
+input_player1_btn_a = "0"
+input_player1_btn_b = "8"
+input_player1_btn_x = "1"
+input_player1_btn_y = "9"

--- a/emu-configs/defaults/retrodeck/presets/remaps/Mesen/nes.rmp.disabled
+++ b/emu-configs/defaults/retrodeck/presets/remaps/Mesen/nes.rmp.disabled
@@ -1,0 +1,4 @@
+input_player1_btn_a = "0"
+input_player1_btn_b = "8"
+input_player1_btn_x = "1"
+input_player1_btn_y = "9"

--- a/emu-configs/defaults/retrodeck/presets/remaps/Mupen64Plus-Next/n64.rmp.disabled
+++ b/emu-configs/defaults/retrodeck/presets/remaps/Mupen64Plus-Next/n64.rmp.disabled
@@ -1,0 +1,4 @@
+input_player1_btn_a = "0"
+input_player1_btn_b = "8"
+input_player1_btn_x = "1"
+input_player1_btn_y = "9"

--- a/emu-configs/defaults/retrodeck/presets/remaps/mGBA/gba.rmp.disabled
+++ b/emu-configs/defaults/retrodeck/presets/remaps/mGBA/gba.rmp.disabled
@@ -1,0 +1,4 @@
+input_player1_btn_a = "0"
+input_player1_btn_b = "8"
+input_player1_btn_x = "1"
+input_player1_btn_y = "9"

--- a/emu-configs/defaults/retrodeck/reference_lists/pretty_system_names.cfg
+++ b/emu-configs/defaults/retrodeck/reference_lists/pretty_system_names.cfg
@@ -1,0 +1,11 @@
+duckstation^Duckstation (Sony Playstation Standalone)
+gb^Nintendo GameBoy
+gba^Nintendo GameBoy Advance
+gbc^Nintendo GameBoy Color
+genesis^Sega Genesis/Master System
+gg^Sega GameGear
+n64^Nintendo 64
+pcsx2^PCSX2 (Sony Playstation 2 Standalone)
+psx_ra^Sony Playstation (RetroArch Core)
+retroarch^RetroArch (Multi-emulator Frontend)
+snes^Nintendo Super Nintendo

--- a/emu-configs/defaults/retrodeck/retrodeck.cfg
+++ b/emu-configs/defaults/retrodeck/retrodeck.cfg
@@ -29,20 +29,34 @@ default_user=
 developer_options=false
 
 [cheevos]
-Duckstation=false
-PCSX2=false
-RetroArch=false
+duckstation=false
+pcsx2=false
+retroarch=false
 
 [cheevos_hardcore]
-Duckstation=false
-PCSX2=false
-RetroArch=false
+duckstation=false
+pcsx2=false
+retroarch=false
 
 [borders]
-SNES=false
+gb=false
+gba=false
+gbc=false
+genesis=false
+gg=false
+n64=false
+psx_ra=false
+snes=false
 
 [widescreen]
-SNES=false
+genesis=false
+n64=false
+psx_ra=false
+snes=false
 
 [nintendo_button_layout]
-SNES=false
+gb=false
+gba=false
+gbc=false
+n64=false
+snes=false

--- a/emu-configs/patches/updates/064b_update.patch
+++ b/emu-configs/patches/updates/064b_update.patch
@@ -2,5 +2,5 @@
 change^DSP^Backend^Pulse^primehack^$primehackconf
 change^Settings^AspectRatio^1^primehack^$primehackgfxconf
 # Update "ask on quit" and "save on quit" on supported emulators (PCSX2, Duckstation)
-change^UI^ConfirmShutdown^false^pcsx2^$pcsx2qtconf
+change^UI^ConfirmShutdown^false^pcsx2^$pcsx2conf
 change^Main^ConfirmPowerOff^false^duckstation^$duckstationconf

--- a/emu-configs/retroarch/retroarch.cfg
+++ b/emu-configs/retroarch/retroarch.cfg
@@ -1,6 +1,6 @@
 accessibility_enable = "false"
 accessibility_narrator_speech_speed = "5"
-ai_service_enable = "true"
+ai_service_enable = "false"
 ai_service_mode = "1"
 ai_service_pause = "false"
 ai_service_source_lang = "0"

--- a/es-configs/es_systems.xml
+++ b/es-configs/es_systems.xml
@@ -1269,7 +1269,7 @@
         <platform>ps3</platform>
         <theme>ps3</theme>
     </system>
-    <system>
+    <!-- <system>
         <name>ps4</name>
         <fullname>Sony PlayStation 4</fullname>
         <path>%ROMPATH%/ps4</path>
@@ -1277,7 +1277,7 @@
         <command>PLACEHOLDER %ROM%</command>
         <platform>ps4</platform>
         <theme>ps4</theme>
-    </system>
+    </system> -->
     <system>
         <name>psp</name>
         <fullname>Sony PlayStation Portable</fullname>

--- a/functions/functions.sh
+++ b/functions/functions.sh
@@ -238,6 +238,14 @@ backup_retrodeck_userdata() {
   zip -rq9 "$backups_folder/$(date +"%0m%0d")_retrodeck_userdata.zip" "$saves_folder" "$states_folder" "$bios_folder" "$media_folder" "$themes_folder" "$logs_folder" "$screenshots_folder" "$mods_folder" "$texture_packs_folder" "$borders_folder" > $logs_folder/$(date +"%0m%0d")_backup_log.log
 }
 
+make_name_pretty() {
+  # This function will take an internal system name (like "gbc") and return a pretty version for user display ("Nintendo GameBoy Color")
+  # USAGE: make_name_pretty "system name"
+  local system=$(grep "$1^" "$pretty_system_names_reference_list")
+  IFS='^' read -r internal_name pretty_name < <(echo "$system")
+  echo "$pretty_name"
+}
+
 finit_browse() {
 # Function for choosing data directory location during first/forced init
 path_selected=false

--- a/functions/global.sh
+++ b/functions/global.sh
@@ -43,8 +43,9 @@ helper_files_list="$emuconfigs/defaults/retrodeck/reference_lists/helper_files_l
 rd_appdata="/app/share/appdata/net.retrodeck.retrodeck.appdata.xml"                                                   # The shipped appdata XML file for this version
 rpcs3_firmware="http://dus01.ps3.update.playstation.net/update/ps3/image/us/2023_0228_05fe32f5dc8c78acbcd84d36ee7fdc5b/PS3UPDAT.PUP"
 RA_API_URL="https://retroachievements.org/dorequest.php"                                                              # API URL for RetroAchievements.org
-presets_dir="$emuconfigs/defaults/retrodeck/presets"
-incompatible_presets_reference_list="$emuconfigs/defaults/retrodeck/reference_lists/incompatible_presets.cfg"
+presets_dir="$emuconfigs/defaults/retrodeck/presets"                                                                  # Repository for all system preset config files
+incompatible_presets_reference_list="$emuconfigs/defaults/retrodeck/reference_lists/incompatible_presets.cfg"         # A config file listing all incompatible presets for reference (eg. cannot have borders and widescreen enabled simultaniously)
+pretty_system_names_reference_list="$emuconfigs/defaults/retrodeck/reference_lists/pretty_system_names.cfg"           # An internal translation list for turning internal names (eg. gbc) to "pretty" names (Nintendo GameBoy Color)
 
 # Config files for emulators with single config files
 

--- a/functions/patching.sh
+++ b/functions/patching.sh
@@ -88,7 +88,7 @@ get_setting_value() {
     if [[ -z $current_section_name ]]; then
       echo $(grep -o -P "(?<=^$current_setting_name=).*" $1)
     else
-      sed -n '\^\['"$current_section_name"'\]^,\^\^'"$current_setting_name"'^{ \^\['"$current_section_name"'\]^! { \^\^'"$current_setting_name"'^ p } }' $1 | grep -o -P "(?<=^$current_setting_name=).*"
+      sed -n -E '\^\['"$current_section_name"'\]^,\^\^'"$current_setting_name"'|\[^{ \^\['"$current_section_name"'\]^! { \^\^'"$current_setting_name"'^ p } }' $1 | grep -o -P "(?<=^$current_setting_name=).*"
     fi
   ;;
 
@@ -96,7 +96,7 @@ get_setting_value() {
     if [[ -z $current_section_name ]]; then
       echo $(grep -o -P "(?<=^$current_setting_name = \").*(?=\")" $1)
     else
-      sed -n '\^\['"$current_section_name"'\]^,\^\^'"$current_setting_name"'^{ \^\['"$current_section_name"'\]^! { \^\^'"$current_setting_name"'^ p } }' $1 | grep -o -P "(?<=^$current_setting_name = \").*(?=\")"
+      sed -n -E '\^\['"$current_section_name"'\]^,\^\^'"$current_setting_name"'|\[^{ \^\['"$current_section_name"'\]^! { \^\^'"$current_setting_name"'^ p } }' $1 | grep -o -P "(?<=^$current_setting_name = \").*(?=\")"
     fi
   ;;
 
@@ -104,7 +104,7 @@ get_setting_value() {
     if [[ -z $current_section_name ]]; then
       echo $(grep -o -P "(?<=^$current_setting_name = ).*" $1)
     else
-      sed -n '\^\['"$current_section_name"'\]^,\^\^'"$current_setting_name"'^{ \^\['"$current_section_name"'\]^! { \^\^'"$current_setting_name"'^ p } }' $1 | grep -o -P "(?<=^$current_setting_name = ).*"
+      sed -n -E '\^\['"$current_section_name"'\]^,\^\^'"$current_setting_name"'|\[^{ \^\['"$current_section_name"'\]^! { \^\^'"$current_setting_name"'^ p } }' $1 | grep -o -P "(?<=^$current_setting_name = ).*"
     fi
   ;;
 

--- a/functions/post_update.sh
+++ b/functions/post_update.sh
@@ -90,9 +90,9 @@ post_update() {
     set_setting_value $rd_conf "borders_folder" "$rdhome/borders"
     conf_read
 
-    mv -f "$pcsx2qtconf" "$pcsx2qtconf.bak"
-    generate_single_patch "$emuconfigs/PCSX2/PCSX2.ini" "$pcsx2qtconf.bak" "/var/config/PCSX2/inis/PCSX2-cheevos-upgrade.patch" pcsx2
-    deploy_single_patch "$emuconfigs/PCSX2/PCSX2.ini" "/var/config/PCSX2/inis/PCSX2-cheevos-upgrade.patch" "$pcsx2qtconf"
+    mv -f "$pcsx2conf" "$pcsx2conf.bak"
+    generate_single_patch "$emuconfigs/PCSX2/PCSX2.ini" "$pcsx2conf.bak" "/var/config/PCSX2/inis/PCSX2-cheevos-upgrade.patch" pcsx2
+    deploy_single_patch "$emuconfigs/PCSX2/PCSX2.ini" "/var/config/PCSX2/inis/PCSX2-cheevos-upgrade.patch" "$pcsx2conf"
     rm -f "/var/config/PCSX2/inis/PCSX2-cheevos-upgrade.patch"
     mv -f "$duckstationconf" "$duckstationconf.bak"
     generate_single_patch "$emuconfigs/duckstation/settings.ini" "$duckstationconf.bak" "/var/config/duckstation/duckstation-cheevos-upgrade.patch" pcsx2

--- a/functions/post_update.sh
+++ b/functions/post_update.sh
@@ -152,6 +152,7 @@ post_update() {
     set_setting_value "$duckstationconf" "Card1Path" "$saves_folder/psx/duckstation/memcards/shared_card_1.mcd" "duckstation" "MemoryCards"
     set_setting_value "$duckstationconf" "Card2Path" "$saves_folder/psx/duckstation/memcards/shared_card_2.mcd" "duckstation" "MemoryCards"
     set_setting_value "$duckstationconf" "Directory" "$saves_folder/psx/duckstation/memcards" "duckstation" "MemoryCards"
+    set_setting_value "$duckstationconf" "RecursivePaths" "$roms_folder/psx" "duckstation" "GameList"
     mkdir -p "$states_folder/psx"
     mv -t "$states_folder/psx/" "$states_folder/duckstation"
     unlink "/var/data/duckstation/savestates"

--- a/functions/prepare_emulator.sh
+++ b/functions/prepare_emulator.sh
@@ -258,6 +258,7 @@ prepare_emulator() {
         set_setting_value "$multi_user_data_folder/$SteamAppUser/data/duckstation/settings.ini" "Card1Path" "$saves_folder/psx/duckstation/memcards/shared_card_1.mcd" "duckstation" "MemoryCards"
         set_setting_value "$multi_user_data_folder/$SteamAppUser/data/duckstation/settings.ini" "Card2Path" "$saves_folder/psx/duckstation/memcards/shared_card_2.mcd" "duckstation" "MemoryCards"
         set_setting_value "$multi_user_data_folder/$SteamAppUser/data/duckstation/settings.ini" "Directory" "$saves_folder/psx/duckstation/memcards" "duckstation" "MemoryCards"
+        set_setting_value "$multi_user_data_folder/$SteamAppUser/data/duckstation/settings.ini" "RecursivePaths" "$roms_folder/psx" "duckstation" "GameList"
         dir_prep "$multi_user_data_folder/$SteamAppUser/config/duckstation" "/var/config/duckstation"
       else # Single-user actions
         rm -rf /var/config/duckstation
@@ -267,6 +268,7 @@ prepare_emulator() {
         set_setting_value "$duckstationconf" "Card1Path" "$saves_folder/psx/duckstation/memcards/shared_card_1.mcd" "duckstation" "MemoryCards"
         set_setting_value "$duckstationconf" "Card2Path" "$saves_folder/psx/duckstation/memcards/shared_card_2.mcd" "duckstation" "MemoryCards"
         set_setting_value "$duckstationconf" "Directory" "$saves_folder/psx/duckstation/memcards" "duckstation" "MemoryCards"
+        set_setting_value "$duckstationconf" "RecursivePaths" "$roms_folder/psx" "duckstation" "GameList"
       fi
       dir_prep "$saves_folder/psx/duckstation/memcards" "/var/config/duckstation/memcards" # TODO: This shouldn't be needed anymore, verify
       dir_prep "$states_folder/psx/duckstation" "/var/config/duckstation/savestates" # This is hard-coded in Duckstation, always needed
@@ -276,6 +278,7 @@ prepare_emulator() {
       set_setting_value "$duckstationconf" "Card1Path" "$saves_folder/psx/duckstation/memcards/shared_card_1.mcd" "duckstation" "MemoryCards"
       set_setting_value "$duckstationconf" "Card2Path" "$saves_folder/psx/duckstation/memcards/shared_card_2.mcd" "duckstation" "MemoryCards"
       set_setting_value "$duckstationconf" "Directory" "$saves_folder/psx/duckstation/memcards" "duckstation" "MemoryCards"
+      set_setting_value "$duckstationconf" "RecursivePaths" "$roms_folder/psx" "duckstation" "GameList"
       dir_prep "$states_folder/psx/duckstation" "/var/config/duckstation/savestates" # This is hard-coded in Duckstation, always needed
     fi
   fi

--- a/functions/prepare_emulator.sh
+++ b/functions/prepare_emulator.sh
@@ -83,6 +83,7 @@ prepare_emulator() {
           set_setting_value "$raconf" "savefile_directory" "$saves_folder" "retroarch"
           set_setting_value "$raconf" "savestate_directory" "$states_folder" "retroarch"
           set_setting_value "$raconf" "screenshot_directory" "$screenshots_folder" "retroarch"
+          set_setting_value "$raconf" "log_dir" "$logs_folder" "retroarch"
         fi
 
         # PPSSPP
@@ -126,6 +127,7 @@ prepare_emulator() {
       set_setting_value "$raconf" "savefile_directory" "$saves_folder" "retroarch"
       set_setting_value "$raconf" "savestate_directory" "$states_folder" "retroarch"
       set_setting_value "$raconf" "screenshot_directory" "$screenshots_folder" "retroarch"
+      set_setting_value "$raconf" "log_dir" "$logs_folder" "retroarch"
     fi
   fi
 

--- a/functions/presets.sh
+++ b/functions/presets.sh
@@ -101,9 +101,8 @@ build_preset_config(){
   local system_being_changed="$1"
   shift
   local presets_being_changed="$*"
-  for preset in $presets_being_changed
+  for current_preset in $presets_being_changed
   do
-    current_preset="$preset"
     local preset_section=$(sed -n '/\['"$current_preset"'\]/, /\[/{ /\['"$current_preset"'\]/! { /\[/! p } }' $rd_conf | sed '/^$/d')
     while IFS= read -r system_line
     do

--- a/functions/presets.sh
+++ b/functions/presets.sh
@@ -24,16 +24,18 @@ change_preset_dialog() {
       elif [[ "$system_value" == "false" ]]; then
         current_disabled_systems=("${current_disabled_systems[@]}" "$system_name")
       fi
-      current_preset_settings=("${current_preset_settings[@]}" "$system_value" "$system_name")
+      current_preset_settings=("${current_preset_settings[@]}" "$system_value" "$(make_name_pretty $system_name)" "$system_name")
   done < <(printf '%s\n' "$section_results")
 
   choice=$(zenity \
     --list --width=1200 --height=720 \
     --checklist \
     --separator="," \
+    --hide-column=3 --print-column=3 \
     --text="Enable $pretty_preset_name:" \
     --column "Enabled" \
     --column "Emulator" \
+    --column "internal_system_name" \
     "${current_preset_settings[@]}")
 
   local rc=$?

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -183,6 +183,7 @@ configurator_global_presets_and_settings_dialog() {
   "Enable/Disable Borders" "Enable or disable borders in supported systems" \
   "Enable/Disable Widescreen" "Enable or disable widescreen in supported systems" \
   "RetroAchievements Login" "Log into the RetroAchievements service in supported systems" \
+  "RetroAchievements Logout" "Disable RetroAchievements service in supported systems" \
   "RetroAchievements Hardcore Mode" "Enable RetroAchievements hardcore mode (no cheats, rewind, save states etc.) in supported emulators" \
   "Nintendo Button Layout" "Enable or disable Nintendo button layout (swapped A/B and X/Y) in supported systems" )
 
@@ -207,6 +208,11 @@ configurator_global_presets_and_settings_dialog() {
     else
       configurator_generic_dialog "RetroDECK Configurator Utility - RetroAchievements" "RetroAchievements login failed, please verify your username and password and try the process again."
     fi
+    configurator_global_presets_and_settings_dialog
+  ;;
+
+  "RetroAchievements Logout" ) # This is a workaround to allow disabling cheevos without having to enter login credentials
+    change_preset_dialog "cheevos"
     configurator_global_presets_and_settings_dialog
   ;;
 


### PR DESCRIPTION
Add Duckstation ROMs folder config setup
Fix PCSX2 config location variable use
Add logs_folder to RetroArch config setup
Add RetroAchievements logout dialog
Disabled AI Service in RetroArch by default
Add preview of USB import tool to Dev Tools dialog
Improve readability of presets dialog
Added internal system name -> User read name translation
Disabled PS4 in es_systems
Improve get_setting_value handling of missing setting name in given section
Added major systems to borders, widescreen and nintendo_button_layout presets