### PR TITLE
Cooker 0.7.0b icenine451

### DIFF
--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -360,7 +360,7 @@ configurator_dolphin_input_textures_dialog() {
 
     if [ $? == 0 ]
     then
-      set_setting_value $dolphingfxconf "HiresTextures" "False" dolphin
+      # set_setting_value $dolphingfxconf "HiresTextures" "False" dolphin # TODO: Break out a preset for texture packs so this can be enabled and disabled independently.
       rm -rf "/var/data/dolphin-emu/Load/DynamicInputTextures"
       configurator_process_complete_dialog "disabling Dolphin custom input textures"
     else
@@ -398,7 +398,7 @@ configurator_primehack_input_textures_dialog() {
 
     if [ $? == 0 ]
     then
-      set_setting_value $primehackgfxconf "HiresTextures" "False" primehack
+      # set_setting_value $primehackgfxconf "HiresTextures" "False" primehack # TODO: Break out a preset for texture packs so this can be enabled and disabled independently.
       rm -rf "/var/data/primehack/Load/DynamicInputTextures"
       configurator_process_complete_dialog "disabling Primehack custom input textures"
     else

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -377,7 +377,7 @@ configurator_dolphin_input_textures_dialog() {
       set_setting_value $dolphingfxconf "HiresTextures" "True" dolphin
       (
         mkdir "/var/data/dolphin-emu/Load/DynamicInputTextures"
-        cp -rf "/app/retrodeck/extras/DynamicInputTextures/*" "/var/data/dolphin-emu/Load/DynamicInputTextures/"
+        rsync -a "/app/retrodeck/extras/DynamicInputTextures/" "/var/data/dolphin-emu/Load/DynamicInputTextures/"
       ) |
       zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
@@ -415,7 +415,7 @@ configurator_primehack_input_textures_dialog() {
       set_setting_value $primehackgfxconf "HiresTextures" "True" primehack
       (
         mkdir "/var/data/primehack/Load/DynamicInputTextures"
-        cp -rf "/app/retrodeck/extras/DynamicInputTextures/*" "/var/data/primehack/Load/DynamicInputTextures/"
+        rsync -a "/app/retrodeck/extras/DynamicInputTextures/" "/var/data/primehack/Load/DynamicInputTextures/"
       ) |
       zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \


### PR DESCRIPTION
Change DynamicInputTexture Configurator install from cp to rsync
Disable disabling "Load Custom Textures" in Dolphin and Primehack when disabling DynamicInputTextures (so other custom textures will still work)