### PR TITLE
Cooker 0.7.0b icenine451

### DIFF
--- a/net.retrodeck.retrodeck.yml
+++ b/net.retrodeck.retrodeck.yml
@@ -72,7 +72,7 @@ modules:
     build-commands:
       - |
 
-        VERSION="cooker-0.7.0b"
+        VERSION=$(git rev-parse --abbrev-ref HEAD)
 
         git checkout ${GITHUB_REF_NAME}
         mkdir -p ${FLATPAK_DEST}/retrodeck/


### PR DESCRIPTION
Stop hard-coding branch section of internal version information and pull from locally fetched repo instead, like is used for GitHub tags already.