### PR TITLE
Add EmuDeck comparison tool

### DIFF
--- a/tools/cmp_emudeck.sh
+++ b/tools/cmp_emudeck.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Compare the retroarch core configurations made by EmuDeck with those by RetroDECK
+# Set KEEP_EMUDECK_CONFIGS env variable to keep the EmuDeck configs in the "emudeck_ra_configs" directory
+
+[[ $# != 2 ]] && echo "Usage: cmp_emudeck [EmuDeck Repo Path] [RetroArch Core]
+Example: cmp_emudeck ~/EmuDeck melonds" && exit 1
+
+emudeck_ra_path="$1/functions/EmuScripts/emuDeckRetroArch.sh"
+retrodeck_ra_path="$(dirname "$0")/../emu-configs/retroarch/retroarch-core-options.cfg"
+core="$2"
+
+# Sanity checks
+if [ ! -f "$emudeck_ra_path" ]; then 
+  echo "Error: There is something wrong with the EmuDeck path"
+  exit 1
+fi
+if [[ -z $(grep $core $retrodeck_ra_path) ]]; then
+  echo "Error: The core could not be found"
+  exit 1
+fi
+
+# Setup
+[[ -d "emudeck_ra_configs" ]] || mkdir emudeck_ra_configs
+echo -n "" > emudeck_ra_configs/"$core".cfg
+
+# Get EmuDeck values of core options
+grep RetroArch_setOverride $emudeck_ra_path | grep $core | while read -r line ; do
+  option=$(echo "$line" | cut -d' ' -f5 | tr -d "'")
+  value=$(echo "$line" | sed 's/^[^"]*"/"/' | tr -d "'")
+  echo "$option = $value" >> emudeck_ra_configs/"$core".cfg
+done
+
+sort -o "emudeck_ra_configs/$core.cfg"{,}
+
+diff -y --suppress-common-lines <(grep $core $retrodeck_ra_path) \
+                                emudeck_ra_configs/$core.cfg
+
+# Cleanup
+[[ -z "${KEEP_EMUDECK_CONFIGS}" ]] && rm -rf emudeck_ra_configs

--- a/tools/cmp_emudeck.sh
+++ b/tools/cmp_emudeck.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Compare the retroarch core configurations made by EmuDeck with those by RetroDECK
 # Set KEEP_EMUDECK_CONFIGS env variable to keep the EmuDeck configs in the "emudeck_ra_configs" directory
+# The EmuDeck repo needs to be available for this script. Clone it from https://github.com/dragoonDorise/EmuDeck
 
 [[ $# != 2 ]] && echo "Usage: cmp_emudeck [EmuDeck Repo Path] [RetroArch Core]
 Example: cmp_emudeck ~/EmuDeck melonds" && exit 1


### PR DESCRIPTION
Adds a simple script for RetroDECK devs to compare the retroarch core configurations made by EmuDeck with those made by RetroDECK.

EmuDeck is a very popular project and therefore has a lot of thought-out configurations already. We should regularly check if they made different decisions and contemplate which one makes more sense.

For example, when I recently switched to RetroDECK from EmuDeck I was a bit disappointed to see that melonDS and mupen64 are not configured to scale the resolution although the Steam Deck is perfectly capable of that.

Here's an example comparison of mupen64plus (EmuDeck on the right):

![emudeck-comparison-mupen64plus](https://github.com/XargonWan/RetroDECK/assets/143698706/ff03ee53-0351-428d-a3a4-403655e39c6d)
