### PR TITLE
Fix the focusing warnings, grab first child in TabContainer

### DIFF
--- a/tools/configurator/TabContainer.gd
+++ b/tools/configurator/TabContainer.gd
@@ -1,14 +1,7 @@
 extends TabContainer
 
-
-# Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-func _process(delta):
-	pass
+	focusFirstFocusableChild() #grab focus on first element to enable controller focusing
 
 func _input(event):
 	if (event.is_action_pressed("next_tab")):

--- a/tools/configurator/main.gd
+++ b/tools/configurator/main.gd
@@ -3,7 +3,7 @@ extends Control
 func _ready():
 	var children = findElements(self, "Control")
 	for n: Control in children: #iterate the children to grab focus on mouse hov
-		if (n.focus_mode != FOCUS_NONE):
+		if (n.focus_mode == FOCUS_ALL):
 			n.mouse_entered.connect(_on_control_mouse_entered.bind(n))
 
 func _input(event):

--- a/tools/configurator/main.gd
+++ b/tools/configurator/main.gd
@@ -1,11 +1,10 @@
 extends Control
 
 func _ready():
-	$MarginContainer/TabContainer/System/ScrollContainer/VBoxContainer/game_control_container/GridContainer/resume.grab_focus() #Required to enable controller focusing
 	var children = findElements(self, "Control")
-	#print(children)
-	for n: Control in children:
-		n.mouse_entered.connect(_on_control_mouse_entered.bind(n))
+	for n: Control in children: #iterate the children to grab focus on mouse hov
+		if (n.focus_mode != FOCUS_NONE):
+			n.mouse_entered.connect(_on_control_mouse_entered.bind(n))
 
 func _input(event):
 	if event.is_action_pressed("quit"):

--- a/tools/configurator/project.godot
+++ b/tools/configurator/project.godot
@@ -69,11 +69,13 @@ quit={
 next_tab={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":10,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":69,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 previous_tab={
 "deadzone": 0.5,
 "events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":9,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":81,"physical_keycode":0,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
 


### PR DESCRIPTION
Cherrypick cipi1965's focusing warning fix
Move focusing first child to TabContainer (and lose hardcoded element focus)