### PR TITLE
Cooker 0.8.0b icenine451

### DIFF
--- a/emu-configs/defaults/retrodeck/presets/retroarch_presets.cfg
+++ b/emu-configs/defaults/retrodeck/presets/retroarch_presets.cfg
@@ -3,5 +3,5 @@ change^cheevos^cheevos_enable^true^^$raconf^$emuconfigs/retroarch/retroarch.cfg
 change^cheevos^cheevos_token^$cheevos_token^^$raconf^$emuconfigs/retroarch/retroarch.cfg
 change^cheevos^cheevos_username^$cheevos_username^^$raconf^$emuconfigs/retroarch/retroarch.cfg
 change^cheevos_hardcore^cheevos_hardcore_mode_enable^true^^$raconf^$emuconfigs/retroarch/retroarch.cfg
-change^savestate_auto_load^savestate_auto_load^true^^$raconf^$emuconfigs/retroarch/retroarch.cfg
-change^savestate_auto_save^savestate_auto_save^true^^$raconf^$emuconfigs/retroarch/retroarch.cfg
+change^quick_resume^savestate_auto_load^true^^$raconf^$emuconfigs/retroarch/retroarch.cfg
+change^quick_resume^savestate_auto_save^true^^$raconf^$emuconfigs/retroarch/retroarch.cfg

--- a/emu-configs/defaults/retrodeck/reference_lists/finit_options_list.cfg
+++ b/emu-configs/defaults/retrodeck/reference_lists/finit_options_list.cfg
@@ -1,3 +1,3 @@
 false^RPCS3 Firmware Install^Install firmware needed for PS3 emulation^rpcs3_firmware
 false^Vita3K Firmware Install^Install firmware needed for Vita3K emulation^vita3k_firmware
-false^RetroDECK Controller Profile^Install custom RetroDECK controller profile^rd_controller_profile
+true^Install RetroDECK Controller Profile^Install custom RetroDECK controller profile^rd_controller_profile

--- a/emu-configs/defaults/retrodeck/retrodeck.cfg
+++ b/emu-configs/defaults/retrodeck/retrodeck.cfg
@@ -72,13 +72,7 @@ n64=false
 snes=false
 yuzu=false
 
-[savestate_auto_load]
-ppsspp=true
-retroarch=true
-
-[savestate_auto_save]
-duckstation=true
-pcsx2=true
+[quick_resume]
 retroarch=true
 
 [ask_to_exit]

--- a/functions/functions.sh
+++ b/functions/functions.sh
@@ -310,7 +310,11 @@ make_name_pretty() {
   # This function will take an internal system name (like "gbc") and return a pretty version for user display ("Nintendo GameBoy Color")
   # USAGE: make_name_pretty "system name"
   local system=$(grep "$1^" "$pretty_system_names_reference_list")
-  IFS='^' read -r internal_name pretty_name < <(echo "$system")
+  if [[ ! -z "$system" ]]; then
+    IFS='^' read -r internal_name pretty_name < <(echo "$system")
+  else
+    pretty_name="$system"
+  fi
   echo "$pretty_name"
 }
 

--- a/functions/post_update.sh
+++ b/functions/post_update.sh
@@ -240,8 +240,10 @@ post_update() {
     # - Determine if Steam is installed via normal desktop application / Flatpak / SteamOS TODO
     # - Install RetroDECK controller profile in desired location TODO
     # - Change section name in retrodeck.cfg for ABXY button swap preset
+    # - Force disable global rewind in RA in prep for preset system
     sed -i 's^nintendo_button_layout^abxy_button_swap^' "$rd_conf" # This is a one-off sed statement as there are no functions for replacing section names
-    
+    set_setting_value "$raconf" "rewind_enable" "false" "retroarch"
+
     # in 3.0 .emulationstation was moved into ES-DE
     mv -f /var/config/emulationstation /var/config/ES-DE
     mv -f /var/config/ES-DE/.emulationstation/* /var/config/ES-DE

--- a/functions/post_update.sh
+++ b/functions/post_update.sh
@@ -246,9 +246,6 @@ post_update() {
 
     # in 3.0 .emulationstation was moved into ES-DE
     mv -f /var/config/emulationstation /var/config/ES-DE
-    mv -f /var/config/ES-DE/.emulationstation/* /var/config/ES-DE
-    rm -rf /var/config/ES-DE/.emulationstation
-    rm -f /var/config/ES-DE/es_settings.xml
 
     prepare_component "reset" "es-de"
     prepare_component "reset" "mame"

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -13,6 +13,7 @@ source /app/libexec/global.sh
 #       - Global: Presets & Settings
 #         - Widescreen: Enable/Disable
 #         - Ask-To-Exit: Enable/Disable
+#         - Quick Resume: Enable/Disable
 #         - RetroAchievements: Login
 #         - RetroAchievements: Logout
 #         - RetroAchievements: Hardcore Mode
@@ -198,6 +199,7 @@ configurator_global_presets_and_settings_dialog() {
   --column="Choice" --column="Action" \
   "Widescreen: Enable/Disable" "Enable or disable widescreen in supported systems" \
   "Ask-to-Exit: Enable/Disable" "Enable or disable emulators confirming when quitting in supported systems" \
+  "Quick Resume: Enable/Disable" "Enable or disable save state auto-save/load in supported systems" \
   "RetroAchievements: Login" "Log into the RetroAchievements service in supported systems" \
   "RetroAchievements: Logout" "Disable RetroAchievements service in ALL supported systems" \
   "RetroAchievements: Hardcore Mode" "Enable RetroAchievements hardcore mode (no cheats, rewind, save states etc.) in supported systems" \
@@ -213,6 +215,11 @@ configurator_global_presets_and_settings_dialog() {
 
   "Ask-to-Exit: Enable/Disable" )
     change_preset_dialog "ask_to_exit"
+    configurator_global_presets_and_settings_dialog
+  ;;
+
+  "Quick Resume: Enable/Disable" )
+    change_preset_dialog "quick_resume"
     configurator_global_presets_and_settings_dialog
   ;;
 

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -17,8 +17,8 @@ source /app/libexec/global.sh
 #         - RetroAchievements: Login
 #         - RetroAchievements: Logout
 #         - RetroAchievements: Hardcore Mode
-#         - Rewind
-#         - Swap A/B and X/Y Buttons
+#         - Rewind: Enable/Disable
+#         - Swap A/B and X/Y Buttons: Enable/Disable
 #       - RetroArch: Presets & Settings
 #         - Borders: Enable/Disable
 #       - Wii & GameCube: Presets & Settings
@@ -203,8 +203,8 @@ configurator_global_presets_and_settings_dialog() {
   "RetroAchievements: Login" "Log into the RetroAchievements service in supported systems" \
   "RetroAchievements: Logout" "Disable RetroAchievements service in ALL supported systems" \
   "RetroAchievements: Hardcore Mode" "Enable RetroAchievements hardcore mode (no cheats, rewind, save states etc.) in supported systems" \
-  "Rewind" "Enable or disable the rewind function in supported systems" \
-  "Swap A/B and X/Y Buttons" "Enable or disable a swapped A/B and X/Y button layout in supported systems" )
+  "Rewind: Enable/Disable" "Enable or disable the rewind function in supported systems" \
+  "Swap A/B and X/Y Buttons: Enable/Disable" "Enable or disable a swapped A/B and X/Y button layout in supported systems" )
 
   case $choice in
 
@@ -251,12 +251,12 @@ configurator_global_presets_and_settings_dialog() {
     configurator_global_presets_and_settings_dialog
   ;;
 
-  "Rewind" )
+  "Rewind: Enable/Disable" )
     change_preset_dialog "rewind"
     configurator_global_presets_and_settings_dialog
   ;;
 
-  "Swap A/B and X/Y Buttons" )
+  "Swap A/B and X/Y Buttons: Enable/Disable" )
     change_preset_dialog "abxy_button_swap"
     configurator_global_presets_and_settings_dialog
   ;;


### PR DESCRIPTION
Merge state auto save/load presets into "quick resume"
Fix some Configurator labels
Add fallback to name-prettification for unknown systems
Force disable global rewind in RA at update for new quick resume preset
Remove unneeded post_update commands for ES-DE
Update RD controller profile install text and make it enabled by default