### PR TITLE
Cooker 0.8.0b icenine451

### DIFF
--- a/functions/dialogs.sh
+++ b/functions/dialogs.sh
@@ -188,8 +188,6 @@ get_cheevos_token_dialog() {
   # This function will return a RetroAchvievements token from a valid username and password, will return "login failed" otherwise
   # USAGE: get_cheevos_token_dialog
 
-  log d "Opening RetroAchievements dialog"
-
   local cheevos_info=$(zenity --forms --title="Cheevos" \
   --text="Username and password." \
   --separator="^" \

--- a/functions/functions.sh
+++ b/functions/functions.sh
@@ -16,7 +16,6 @@ directory_browse() {
       if [ $? == 0 ]
       then
         path_selected=true
-        log i "\"$target\" selected."
         echo "$target"
         break
       fi
@@ -47,7 +46,6 @@ file_browse() {
       if [ $? == 0 ]
       then
         file_selected=true
-        log i "\"$target\" selected."
         echo "$target"
         break
       fi
@@ -71,12 +69,9 @@ verify_space() {
   source_size=$((source_size+(source_size/10))) # Add 10% to source size for safety
   dest_avail=$(df -k --output=avail "$2" | tail -1)
 
-  log i "Checking free disk space"
   if [[ $source_size -ge $dest_avail ]]; then
-    log e "Not enough disk space: $dest_avail"
     echo "false"
   else
-    log i "Disk space is enough: $dest_avail"
     echo "true"
   fi
 }
@@ -368,7 +363,6 @@ do
       if [ $? == 0 ] #yes
       then
         path_selected=true
-        log i "\"$target/retrodeck\" selected."
         echo "$target/retrodeck"
         break
       else
@@ -410,7 +404,6 @@ finit_user_options_dialog() {
   --column "option_flag" \
   "${finit_available_options[@]}")
 
-  log i "User choiches: \"${choices[*]}\"."
   echo "${choices[*]}"
 }
 
@@ -652,7 +645,7 @@ manage_ryujinx_keys() {
 
               # Create symlink
               ln -s "$file" "$symlink"
-              echo "Created symlink: \"$symlink\""
+              log i "Created symlink: \"$symlink\""
           done
       else
           log w "No files found in $bios_folder/switch/keys. Continuing..."

--- a/functions/global.sh
+++ b/functions/global.sh
@@ -26,13 +26,14 @@ zip_compressable_extensions="$emuconfigs/defaults/retrodeck/reference_lists/zip_
 easter_egg_checklist="$emuconfigs/defaults/retrodeck/reference_lists/easter_egg_checklist.cfg"                        # A config file listing days and times when special splash screens should show up
 input_validation="$emuconfigs/defaults/retrodeck/reference_lists/input_validation.cfg"                                # A config file listing valid CLI inputs
 finit_options_list="$emuconfigs/defaults/retrodeck/reference_lists/finit_options_list.cfg"                            # A config file listing available optional installs during finit
-splashscreen_dir="/var/config/ES-DE/resources/graphics/extra_splashes"                   # The default location of extra splash screens
-current_splash_file="/var/config/ES-DE/resources/graphics/splash.svg"                    # The active splash file that will be shown on boot
-default_splash_file="/var/config/ES-DE/resources/graphics/splash-orig.svg"               # The default RetroDECK splash screen
+splashscreen_dir="/var/config/ES-DE/resources/graphics/extra_splashes"                                                # The default location of extra splash screens
+current_splash_file="/var/config/ES-DE/resources/graphics/splash.svg"                                                 # The active splash file that will be shown on boot
+default_splash_file="/var/config/ES-DE/resources/graphics/splash-orig.svg"                                            # The default RetroDECK splash screen
 multi_user_emulator_config_dirs="$emuconfigs/defaults/retrodeck/reference_lists/multi_user_emulator_config_dirs.cfg"  # A list of emulator config folders that can be safely linked/unlinked entirely in multi-user mode
-rd_es_themes="/app/share/es-de/themes"                                                                     # The directory where themes packaged with RetroDECK are stored
-lockfile="/var/config/retrodeck/.lock"                                                                                # where the lockfile is located
+rd_es_themes="/app/share/es-de/themes"                                                                                # The directory where themes packaged with RetroDECK are stored
+lockfile="/var/config/retrodeck/.lock"                                                                                # Where the lockfile is located
 default_sd="/run/media/mmcblk0p1"                                                                                     # Steam Deck SD default path
+rd_logs_folder="/var/config/retrodeck/logs/"                                                                          # A static location for RetroDECK logs to be written
 hard_version="$(cat '/app/retrodeck/version')"                                                                        # hardcoded version (in the readonly filesystem)
 rd_repo="https://github.com/XargonWan/RetroDECK"                                                                      # The URL of the main RetroDECK GitHub repo
 es_themes_list="https://gitlab.com/es-de/themes/themes-list/-/raw/master/themes.json"                                 # The URL of the ES-DE 2.0 themes list
@@ -127,6 +128,7 @@ fi
 # If there is no config file I initalize the file with the the default values
 if [[ ! -f "$rd_conf" ]]; then
   create_dir /var/config/retrodeck
+  create_dir /var/config/retrodeck/logs
   log w "RetroDECK config file not found in $rd_conf"
   log i "Initializing"
   # if we are here means that the we are in a new installation, so the version is valorized with the hardcoded one
@@ -164,7 +166,7 @@ if [[ ! -f "$rd_conf" ]]; then
 
   log i "Setting config file permissions"
   chmod +rw $rd_conf
-  log i "RetroDECK config file initialized. Contents:\n\n$(cat $rd_conf\n)"
+  log i "RetroDECK config file initialized. Contents:\n\n$(cat $rd_conf)\n"
   conf_read # Load new variables into memory
   tmplog_merger
 

--- a/functions/logger.sh
+++ b/functions/logger.sh
@@ -28,7 +28,7 @@ log() {
     if [ -n "$3" ]; then
         logfile="$3"
     else
-        logfile="$logs_folder/retrodeck.log"
+        logfile="$rd_logs_folder/retrodeck.log"
     fi
 
     # Check if the shell is sh (not bash or zsh) to avoid colorization
@@ -100,16 +100,16 @@ log() {
 # This function is merging the temporary log file into the actual one
 tmplog_merger() {
 
-    create_dir "$logs_folder"
+    create_dir "$rd_logs_folder"
 
     # Check if /tmp/retrodeck.log exists
-    if [ -e "/tmp/retrodeck.log" ] && [ -e "$logs_folder/retrodeck.log" ]; then
+    if [ -e "/tmp/retrodeck.log" ] && [ -e "$rd_logs_folder/retrodeck.log" ]; then
 
         # Sort both temporary and existing log files by timestamp
-        sort -k1,1n -k2,2M -k3,3n -k4,4n -k5,5n "/tmp/retrodeck.log" "$logs_folder/retrodeck.log" > "$logs_folder/merged_logs.tmp"
+        sort -k1,1n -k2,2M -k3,3n -k4,4n -k5,5n "/tmp/retrodeck.log" "$rd_logs_folder/retrodeck.log" > "$rd_logs_folder/merged_logs.tmp"
 
         # Move the merged logs to replace the original log file
-        mv "$logs_folder/merged_logs.tmp" "$logs_folder/retrodeck.log"
+        mv "$rd_logs_folder/merged_logs.tmp" "$rd_logs_folder/retrodeck.log"
 
         # Remove the temporary file
         rm "/tmp/retrodeck.log"
@@ -119,8 +119,8 @@ tmplog_merger() {
     # Check if the source file exists
     if [ -e "$ESDE_source_logs" ]; then
         # Create the symlink in the logs folder
-        ln -sf "$ESDE_source_logs" "$logs_folder/ES-DE.log"
-        log i "ES-DE log file linked to \"$logs_folder/ES-DE.log\""
+        ln -sf "$ESDE_source_logs" "$rd_logs_folder/ES-DE.log"
+        log i "ES-DE log file linked to \"$rd_logs_folder/ES-DE.log\""
     fi
 
 }

--- a/functions/prepare_component.sh
+++ b/functions/prepare_component.sh
@@ -24,6 +24,7 @@ prepare_component() {
         fi
       done < <(grep -v '^\s*$' $rd_conf | awk '/^\[paths\]/{f=1;next} /^\[/{f=0} f')
       create_dir "/var/config/retrodeck/godot"
+      dir_prep "$rd_logs_folder" "$logs_folder"
     fi
     if [[ "$action" == "postmove" ]]; then # Update the paths of any folders that came with the retrodeck folder during a move
       while read -r config_line; do
@@ -35,6 +36,7 @@ prepare_component() {
           fi
         fi
       done < <(grep -v '^\s*$' $rd_conf | awk '/^\[paths\]/{f=1;next} /^\[/{f=0} f')
+      dir_prep "$rd_logs_folder" "$logs_folder"
     fi
   fi
 


### PR DESCRIPTION
Moved default RD log folder to internal space, then dir_prep after user selects install location
Removed log statements where they would break returned information