### PR TITLE
Update net.retrodeck.retrodeck.appdata.xml to use branding tag

### DIFF
--- a/net.retrodeck.retrodeck.appdata.xml
+++ b/net.retrodeck.retrodeck.appdata.xml
@@ -60,6 +60,10 @@
       <p>Discord: https://discord.gg/WDc5C9YWMx 
          (If you want to help out with the project join the "i-want-to-help" channel)</p>
    </description>
+   <branding>
+      <color type="primary" scheme_preference="light">#94a6fb</color>
+      <color type="primary" scheme_preference="dark">#404b98</color>
+   </branding>
    <project_license>GPL-3.0</project_license>
    <metadata_license>CC0-1.0</metadata_license>
    <releases>


### PR DESCRIPTION
Based on color in center T of logo, #6c7df5, going three shades darker and three shades lighter

Flathub is requiring the use of the branding tag going forward for the Metadata reviews and will feature apps that use the <branding> tag: https://docs.flathub.org/blog/introducing-app-brand-colors/

Guidelines: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#brand-colors

What it would look like using the preview tool at https://docs.flathub.org/banner-preview/:

![image](https://github.com/XargonWan/RetroDECK/assets/165470978/0b3511c7-6d73-435d-84ee-c97fa6492066)

Example of a banner as it would appear on Flathub:

![image](https://github.com/XargonWan/RetroDECK/assets/165470978/1fdfc642-b3aa-425f-bdf0-31f54e412bea)
