### PR TITLE
Fix validate_for_chd and unquoted log line

### DIFF
--- a/functions/compression.sh
+++ b/functions/compression.sh
@@ -34,7 +34,7 @@ find_compatible_compression_format() {
   local normalized_filename=$(echo "$1" | tr '[:upper:]' '[:lower:]')
   local system=$(echo "$1" | grep -oE "$roms_folder/[^/]+" | grep -oE "[^/]+$")
 
-	if [[ $(validate_for_chd "$1") == *"true" ]] && [[ $(sed -n '/^\[/{h;d};/\b'"$system"'\b/{g;s/\[\(.*\)\]/\1/p;q};' $compression_targets) == "chd" ]]; then
+	if [[ $(validate_for_chd "$1") == "true" ]] && [[ $(sed -n '/^\[/{h;d};/\b'"$system"'\b/{g;s/\[\(.*\)\]/\1/p;q};' $compression_targets) == "chd" ]]; then
     echo "chd"
   elif grep -qF ".${normalized_filename##*.}" $zip_compressable_extensions && [[ $(sed -n '/^\[/{h;d};/\b'"$system"'\b/{g;s/\[\(.*\)\]/\1/p;q};' $compression_targets) == "zip" ]]; then
     echo "zip"

--- a/functions/compression.sh
+++ b/functions/compression.sh
@@ -34,7 +34,7 @@ find_compatible_compression_format() {
   local normalized_filename=$(echo "$1" | tr '[:upper:]' '[:lower:]')
   local system=$(echo "$1" | grep -oE "$roms_folder/[^/]+" | grep -oE "[^/]+$")
 
-	if [[ $(validate_for_chd "$1") == "true" ]] && [[ $(sed -n '/^\[/{h;d};/\b'"$system"'\b/{g;s/\[\(.*\)\]/\1/p;q};' $compression_targets) == "chd" ]]; then
+	if [[ $(validate_for_chd "$1") == *"true" ]] && [[ $(sed -n '/^\[/{h;d};/\b'"$system"'\b/{g;s/\[\(.*\)\]/\1/p;q};' $compression_targets) == "chd" ]]; then
     echo "chd"
   elif grep -qF ".${normalized_filename##*.}" $zip_compressable_extensions && [[ $(sed -n '/^\[/{h;d};/\b'"$system"'\b/{g;s/\[\(.*\)\]/\1/p;q};' $compression_targets) == "zip" ]]; then
     echo "zip"
@@ -66,7 +66,7 @@ validate_for_chd() {
         log i "Validating .cue associated .bin files"
         local cue_bin_files=$(grep -o -P "(?<=FILE \").*(?=\".*$)" "$file")
         log i "Associated bin files read:"
-        log i $(printf '%s\n' "$cue_bin_files")
+        log i "$(printf '%s\n' "$cue_bin_files")"
         if [[ ! -z "$cue_bin_files" ]]; then
           while IFS= read -r line
           do

--- a/functions/logger.sh
+++ b/functions/logger.sh
@@ -86,11 +86,11 @@ log() {
   esac
 
   # Display the message in the terminal
-  echo -e "$colored_message"
+  echo -e "$colored_message" >&2
 
   # Write the log message to the log file
   if [ ! -f "$logfile" ]; then
-    echo "$timestamp [WARN] Log file not found in \"$logfile\", creating it"
+    echo "$timestamp [WARN] Log file not found in \"$logfile\", creating it" >&2
     touch "$logfile"
   fi
   echo "$log_message" >> "$logfile"


### PR DESCRIPTION
compression.sh line 37:
```
if [[ $(validate_for_chd "$1") == "true" ]] && ...
```
is currently broken. `validate_for_chd` has several `log` calls, and the `log` function echoes to stdout as well as logging to file, which causes things like this to have problems. Running `find_compatible_compression_format` with `set -x` shows what's happening:

```
...
++ IFS=
++ read -r line
++ echo true
+ [[ [2024-05-14 13:24:42.662] [INFO] Validating file: /home/alexmeyer/retrodeck/roms/psx/Disney-Pixar Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).cue
[2024-05-14 13:24:42.667] [INFO] .cue/.iso/.gdi file detected
[2024-05-14 13:24:42.674] [INFO] Validating .cue associated .bin files
[2024-05-14 13:24:42.678] [INFO] Associated bin files read:
[2024-05-14 13:24:42.681] [INFO] Disney-Pixar
[2024-05-14 13:24:42.681] [WARN] Log file not found in "Toy", creating it
[2024-05-14 13:24:42.693] [INFO] Looking for /var/home/alexmeyer/retrodeck/roms/psx/Disney-Pixar Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).bin
[2024-05-14 13:24:42.695] [INFO] .bin file found at /var/home/alexmeyer/retrodeck/roms/psx/Disney-Pixar Toy Story 2 - Buzz Lightyear to the Rescue! (USA) (Rev 1).bin
true == \t\r\u\e ]]
...
```

That whole log section is the string that's being compared to 'true', which obviously fails. The easy fix is what I added, which is just comparing to *true so the rest of that string doesn't affect it, but this definitely needs some re-working on a deeper level.

The other thing I fixed is one unquoted `log` on line 69 that breaks if the target filename has spaces in it.