### PR TITLE
Cooker 0.8.2b icenine451

### DIFF
--- a/functions/configurator_functions.sh
+++ b/functions/configurator_functions.sh
@@ -31,3 +31,34 @@ check_bios_files() {
       fi
   done < $bios_checklist
 }
+
+find_empty_rom_folders() {
+  # This function will build an array of all the system subfolders in $roms_folder which are either empty or contain only systeminfo.txt for easy removal
+
+  if [[ -f "$godot_empty_roms_folders" ]]; then
+    rm -f "$godot_empty_roms_folders" # Godot data transfer temp files
+  fi
+  touch "$godot_empty_roms_folders"
+
+  empty_rom_folders_list=()
+  all_empty_folders=()
+
+  for system in $(find "$roms_folder" -mindepth 1 -maxdepth 1 -type d -printf '%f\n')
+  do
+    local dir="$roms_folder/$system"
+    local files=$(ls -A1 "$dir")
+    local count=$(ls -A "$dir" | wc -l)
+
+    if [[ $count -eq 0 ]]; then
+        # Directory is empty
+        empty_rom_folders_list=("${empty_rom_folders_list[@]}" "false" "$(realpath $dir)")
+        all_empty_folders=("${all_empty_folders[@]}" "$(realpath $dir)")
+        echo "$(realpath $dir)" >> "$godot_empty_roms_folders" # Godot data transfer temp file
+    elif [[ $count -eq 1 ]] && [[ "$(basename "${files[0]}")" == "systeminfo.txt" ]]; then
+        # Directory contains only systeminfo.txt
+        empty_rom_folders_list=("${empty_rom_folders_list[@]}" "false" "$(realpath $dir)")
+        all_empty_folders=("${all_empty_folders[@]}" "$(realpath $dir)")
+        echo "$(realpath $dir)" >> "$godot_empty_roms_folders" # Godot data transfer temp file
+    fi
+  done
+}

--- a/functions/global.sh
+++ b/functions/global.sh
@@ -55,6 +55,7 @@ pretty_system_names_reference_list="$emuconfigs/defaults/retrodeck/reference_lis
 godot_bios_files_checked="/var/config/retrodeck/godot/godot_bios_files_checked.tmp"
 godot_current_preset_settings="/var/config/retrodeck/godot/godot_current_preset_settings.tmp"
 godot_compression_compatible_games="/var/config/retrodeck/godot/godot_compression_compatible_games.tmp"
+godot_empty_roms_folders="/var/config/retrodeck/godot/godot_empty_roms_folders.tmp"
 
 # Config files for emulators with single config files
 

--- a/functions/prepare_component.sh
+++ b/functions/prepare_component.sh
@@ -12,10 +12,12 @@ prepare_component() {
   action="$1"
   component=$(echo "$2" | tr '[:upper:]' '[:lower:]')
   call_source="$3"
+  component_found="false"
 
   log d "Preparing component: \"$component\", action: \"$action\""
 
   if [[ "$component" == "retrodeck" ]]; then
+    component_found="true"
     if [[ "$action" == "reset" ]]; then # Update the paths of all folders in retrodeck.cfg and create them
       while read -r config_line; do
         local current_setting_name=$(get_setting_name "$config_line" "retrodeck")
@@ -49,9 +51,10 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(es-de|all)$ ]]; then # For use after ESDE-related folders are moved or a reset
-      log i "--------------------------------"
-      log i "Prepearing ES-DE"
-      log i "--------------------------------"
+    component_found="true"
+    log i "--------------------------------"
+    log i "Prepearing ES-DE"
+    log i "--------------------------------"
     if [[ "$action" == "reset" ]]; then
       rm -rf /var/config/ES-DE
       create_dir /var/config/ES-DE/settings
@@ -77,9 +80,10 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(retroarch|all)$ ]]; then
-      log i "--------------------------------"
-      log i "Prepearing RetroArch"
-      log i "--------------------------------"
+  component_found="true"
+    log i "--------------------------------"
+    log i "Prepearing RetroArch"
+    log i "--------------------------------"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       if [[ $multi_user_mode == "true" ]]; then # Multi-user actions
         create_dir -d "$multi_user_data_folder/$SteamAppUser/config/retroarch"
@@ -211,6 +215,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(citra|citra-emu|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "------------------------"
       log i "Prepearing CITRA"
@@ -256,6 +261,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(cemu|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "----------------------"
       log i "Prepearing CEMU"
@@ -283,6 +289,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(dolphin|dolphin-emu|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "----------------------"
       log i "Prepearing DOLPHIN"
@@ -336,6 +343,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(duckstation|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "------------------------"
       log i "Prepearing DUCKSTATION"
@@ -381,6 +389,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(melonds|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "----------------------"
       log i "Prepearing MELONDS"
@@ -419,6 +428,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(pcsx2|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "----------------------"
       log i "Prepearing PCSX2"
@@ -463,6 +473,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(pico8|pico-8|all)$ ]]; then
+  component_found="true"
     if [[ ("$action" == "reset") || ("$action" == "postmove") ]]; then
       dir_prep "$bios_folder/pico-8" "$HOME/.lexaloffle/pico-8" # Store binary and config files together. The .lexaloffle directory is a hard-coded location for the PICO-8 config file, cannot be changed
       dir_prep "$roms_folder/pico8" "$bios_folder/pico-8/carts" # Symlink default game location to RD roms for cleanliness (this location is overridden anyway by the --root_path launch argument anyway)
@@ -473,6 +484,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(ppsspp|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "------------------------"
       log i "Prepearing PPSSPPSDL"
@@ -501,6 +513,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(primehack|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "----------------------"
       log i "Prepearing Primehack"
@@ -544,6 +557,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(rpcs3|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "------------------------"
       log i "Prepearing RPCS3"
@@ -580,6 +594,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(ryujinx|all)$ ]]; then
+  component_found="true"
     # NOTE: for techincal reasons the system folder of Ryujinx IS NOT a sumlink of the bios/switch/keys as not only the keys are located there
     # When RetroDECK starts there is a "manage_ryujinx_keys" function that symlinks the keys only in Rryujinx/system.
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
@@ -624,6 +639,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(yuzu|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "----------------------"
       log i "Prepearing YUZU"
@@ -677,6 +693,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(xemu|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "------------------------"
       log i "Prepearing XEMU"
@@ -721,6 +738,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(vita3k|all)$ ]]; then
+  component_found="true"
     if [[ "$action" == "reset" ]]; then # Run reset-only commands
       log i "----------------------"
       log i "Prepearing Vita3K"
@@ -745,6 +763,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(mame|all)$ ]]; then
+  component_found="true"
     # TODO: do a proper script
     # This is just a placeholder script to test the emulator's flow
     log i "----------------------"
@@ -814,6 +833,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(gzdoom|all)$ ]]; then
+  component_found="true"
     # TODO: do a proper script
     # This is just a placeholder script to test the emulator's flow
     log i "----------------------"
@@ -834,6 +854,7 @@ prepare_component() {
   fi
 
   if [[ "$component" =~ ^(boilr|all)$ ]]; then
+  component_found="true"
     log i "----------------------"
     log i "Prepearing BOILR"
     log i "----------------------"
@@ -842,7 +863,7 @@ prepare_component() {
     cp -fvr "/app/libexec/steam-sync/config.toml" "/var/config/boilr"
   fi
 
-  if [[ ! "$component" =~ ^(retrodeck|es-de|retroarch|citra|citra-emu|cemu|dolphin|dolphin-emu|duckstation|melonds|melonDS|pcsx2|pico8|pico-8|ppsspp|primehack|rpcs3|ryujinx|yuzu|xemu|vita3k|mame|gzdoom|boilr|)$ ]]; then
+  if [[ $component_found="false" ]]; then
     log e "Supplied component $component not found, not resetting"
   fi
 

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -53,6 +53,7 @@ source /app/libexec/global.sh
 #         - Move Mods folder
 #         - Move Texture Packs folder
 #       - Tool: Remove Empty ROM Folders
+#       - Tool: Rebuild All ROM Folders
 #       - Tool: Compress Games
 #         - Compress Single Game
 #         - Compress Multiple Games - CHD
@@ -561,6 +562,7 @@ configurator_retrodeck_tools_dialog() {
   local choices=(
   "Tool: Move Folders" "Move RetroDECK folders between internal/SD card or to a custom location"
   "Tool: Remove Empty ROM Folders" "Remove some or all of the empty ROM folders"
+  "Tool: Rebuild All ROM Folders" "Rebuild any missing default ROM folders"
   "Tool: Compress Games" "Compress games for systems that support it"
   "Install: RetroDECK Controller Layouts" "Install the custom RetroDECK controller layouts on Steam"
   "Install: PS3 Firmware" "Download and install PS3 firmware for use with the RPCS3 emulator"
@@ -613,6 +615,16 @@ configurator_retrodeck_tools_dialog() {
         rm -f "$folder"
       done
     fi
+    
+    configurator_generic_dialog "RetroDECK Configurator - Remove Empty ROM Folders" "The removal process is complete."
+    configurator_retrodeck_tools_dialog
+  ;;
+
+  "Tool: Rebuild All ROM Folders" )
+    log i "Configurator: opening \"$choice\" menu"
+    es-de --create-system-dirs
+    configurator_generic_dialog "RetroDECK Configurator - Rebuild All ROM Folders" "The rebuilding process is complete.\n\nAll missing default ROM folders will now exist in $roms_folder"
+    configurator_retrodeck_tools_dialog
   ;;
 
   "Tool: Compress Games" )

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -52,6 +52,7 @@ source /app/libexec/global.sh
 #         - Move Screenshots folder
 #         - Move Mods folder
 #         - Move Texture Packs folder
+#       - Tool: Remove Empty ROM Folders
 #       - Tool: Compress Games
 #         - Compress Single Game
 #         - Compress Multiple Games - CHD
@@ -559,6 +560,7 @@ configurator_retrodeck_tools_dialog() {
 
   local choices=(
   "Tool: Move Folders" "Move RetroDECK folders between internal/SD card or to a custom location"
+  "Tool: Remove Empty ROM Folders" "Remove some or all of the empty ROM folders"
   "Tool: Compress Games" "Compress games for systems that support it"
   "Install: RetroDECK Controller Layouts" "Install the custom RetroDECK controller layouts on Steam"
   "Install: PS3 Firmware" "Download and install PS3 firmware for use with the RPCS3 emulator"
@@ -583,6 +585,34 @@ configurator_retrodeck_tools_dialog() {
   "Tool: Move Folders" )
     log i "Configurator: opening \"$choice\" menu"
     configurator_retrodeck_move_tool_dialog
+  ;;
+
+  "Tool: Remove Empty ROM Folders" )
+    log i "Configurator: opening \"$choice\" menu"
+    find_empty_rom_folders
+
+    choice=$(zenity \
+        --list --width=1200 --height=720 --title "RetroDECK Configurator - RetroDECK: Remove Empty ROM Folders" \
+        --checklist --hide-column=3 --ok-label="Remove Selected" --extra-button="Remove All" \
+        --separator="," --print-column=2 \
+        --text="Choose which ROM folders to remove:" \
+        --column "Remove?" \
+        --column "System" \
+        "${empty_rom_folders_list[@]}")
+    
+    local rc=$?
+    if [[ $rc == "0" && ! -z $choice ]]; then # User clicked "Remove Selected" with at least one system selected
+      IFS="," read -ra folders_to_remove <<< "$choice"
+      for folder in "${folders_to_remove[@]}"; do
+        log i "Removing empty folder $folder"
+        rm -f "$folder"
+      done
+    elif [[ ! -z $choice ]]; then # User clicked "Remove All"
+      for folder in "${all_empty_folders[@]}"; do
+        log i "Removing empty folder $folder"
+        rm -f "$folder"
+      done
+    fi
   ;;
 
   "Tool: Compress Games" )


### PR DESCRIPTION
- Improved prepare_component safelock for being passed incorrect options
- Added tools to remove empty (or only containing systeminfo.txt) roms folders, and also rebuild any missing folders.