### PR TITLE
Cooker 0.8.2b icenine451

### DIFF
--- a/functions/compression.sh
+++ b/functions/compression.sh
@@ -130,10 +130,10 @@ find_compatible_games() {
   fi
   touch "$godot_compression_compatible_games"
 
-  local compressable_games_list=()
-  local all_compressable_games=()
-  local games_to_compress=()
-  local target_selection="$1"
+  compressable_games_list=()
+  all_compressable_games=()
+  games_to_compress=()
+  target_selection="$1"
 
   if [[ "$1" == "everything" ]]; then
     local compression_format="all"

--- a/functions/presets.sh
+++ b/functions/presets.sh
@@ -41,14 +41,14 @@ build_preset_list_options() {
   fi
   touch "$godot_current_preset_settings"
 
-  local preset="$1"
+  preset="$1"
   pretty_preset_name=${preset//_/ } # Preset name prettification
   pretty_preset_name=$(echo $pretty_preset_name | awk '{for(i=1;i<=NF;i++){$i=toupper(substr($i,1,1))substr($i,2)}}1') # Preset name prettification
-  local current_preset_settings=()
-  local current_enabled_systems=()
-  local current_disabled_systems=()
-  local changed_systems=()
-  local changed_presets=()
+  current_preset_settings=()
+  current_enabled_systems=()
+  current_disabled_systems=()
+  changed_systems=()
+  changed_presets=()
   local section_results=$(sed -n '/\['"$preset"'\]/, /\[/{ /\['"$preset"'\]/! { /\[/! p } }' $rd_conf | sed '/^$/d')
 
   while IFS= read -r config_line


### PR DESCRIPTION
Un-localize variabled used in the compression and presets functions. They were previously only used in one function each, but as I am breaking out functions for use in Godot, the variables need to be used globally now.