### PR TITLE
Implement rd_zenity function

### DIFF
--- a/emu-configs/gzdoom/gzdoom.sh
+++ b/emu-configs/gzdoom/gzdoom.sh
@@ -68,7 +68,7 @@ else
     # Check if the .doom file exists
     if [[ ! -e "$doom_file" ]]; then
         log e "doom file not found in \"$doom_file\""
-        zenity --error --no-wrap \
+        rd_zenity --error --no-wrap \
 	    --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
 	    --title "RetroDECK" \
 	    --text="File \"$doom_file\" not found. Quitting."
@@ -85,7 +85,7 @@ else
         # If the file is not found, exit with an error
         if [[ -z "$found_file" ]]; then
             log "[ERROR] File not found in \"$line\""
-            zenity --error --no-wrap \
+            rd_zenity --error --no-wrap \
                 --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
                 --title "RetroDECK" \
                 --text="File \"$doom_file\" not found. Quitting."

--- a/functions/050_save_migration.sh
+++ b/functions/050_save_migration.sh
@@ -54,7 +54,7 @@ save_migration() {
     save_backup_file=$rdhome/savebackup_"$(date +"%Y_%m_%d_%I_%M_%p").zip"
     state_backup_file=$rdhome/statesbackup_"$(date +"%Y_%m_%d_%I_%M_%p").zip"
 
-    zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK" \
       --text="You are updating to a version of RetroDECK where save file locations have changed!\n\nYour existing files will be backed up for safety and then sorted automatically.\n\nIf a file cannot be sorted automatically it will remain where it is for manual sorting.\n\nPLEASE BE PATIENT! This process can take several minutes if you have a large ROM library."
@@ -144,7 +144,7 @@ save_migration() {
     done
 
     ) |
-    zenity --progress \
+    rd_zenity --progress \
     --icon-name=net.retrodeck.retrodeck \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title="Processing Files" \
@@ -154,14 +154,14 @@ save_migration() {
     --auto-close
 
     if [[ $(cat $migration_logfile | grep "ERROR" | wc -l) -eq 0 ]]; then
-      zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
+      rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK" \
       --text="The migration process has sorted all of your files automatically.\n\nEverything should be working normally, if you experience any issues please check the RetroDECK wiki or contact us directly on the Discord."
 
     else
       cat $migration_logfile | grep "ERROR" > "$rdhome/manual_sort_needed.log"
-      zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
+      rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK" \
       --text="The migration process was unable to sort $(cat $migration_logfile | grep "ERROR" | wc -l) files automatically.\n\nThese files will need to be moved manually to their new locations, find more detail on the RetroDECK wiki.\n\nA log of the files that need manual sorting can be found at $rdhome/manual_sort_needed.log"

--- a/functions/checks.sh
+++ b/functions/checks.sh
@@ -51,7 +51,7 @@ check_for_version_update() {
 
     if [[ ! "$update_ignore" == "$online_version" ]]; then
       if [[ "$update_repo" == "RetroDECK" ]] && [[ $(sed -e 's/[\.a-z]//g' <<< $version) -le $(sed -e 's/[\.a-z]//g' <<< $online_version) ]]; then
-        # choice=$(zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="Ignore this version" \
+        # choice=$(rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="Ignore this version" \
         #   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
         #   --title "RetroDECK Update Available" \
         #   --text="There is a new version of RetroDECK on the stable release channel $online_version. Would you like to update to it?\n\n(depending on your internet speed this could takes several minutes).")
@@ -65,7 +65,7 @@ check_for_version_update() {
         #   (
         #   flatpak-spawn --host flatpak update --noninteractive -y net.retrodeck.retrodeck
         #   ) |
-        #   zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+        #   rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
         #   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
         #   --title "RetroDECK Updater" \
         #   --text="Upgrade in process please wait (this could takes several minutes)."
@@ -74,7 +74,7 @@ check_for_version_update() {
         # fi
         # TODO: add the logic to check and update the branch from the configuration file
         log i "Showing new version found dialog"
-        choice=$(zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="OK" --extra-button="Ignore this version" \
+        choice=$(rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="OK" --extra-button="Ignore this version" \
         --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
         --title "RetroDECK - New Update Available" \
         --text="There is a new version of RetroDECK available: <span foreground='$blue'><b>$online_version</b></span>.\nYou can easily update from the app store you have installed, examples: KDE Discover or Gnome Software.\n\nIf you would like to ignore this notification, click the \"Ignore this version\" button.")
@@ -85,7 +85,7 @@ check_for_version_update() {
         fi
       elif [[ "$update_repo" == "RetroDECK-cooker" ]] && [[ ! $version == $online_version ]]; then
         log i "Showing update request dialog as \"$online_version\" was found and is greater then \"$version\""
-        choice=$(zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="Ignore this version" \
+        choice=$(rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="Ignore this version" \
           --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
           --title "RetroDECK - New Cooker Version Available" \
           --text="There is a more recent version of RetroDECK cooker.\nYou are running version <span foreground='$blue'><b>$hard_version</b></span>. The latest is <span foreground='$blue'><b>$online_version</b></span>.\n\nWould you like to update?\nIf you would like to ignore this notification, click the \"Ignore this version\" button.\n\nIf you would like to disable these notifications entirely: disable Online Update Checks in the Configurator.")
@@ -141,7 +141,7 @@ check_for_version_update() {
 
           rm -rf "$temp_folder" # Cleanup old bundles to save space
           ) |
-          zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+          rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
           --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
           --title "RetroDECK Updater" \
           --text="RetroDECK is updating to the latest version, please wait."

--- a/functions/dialogs.sh
+++ b/functions/dialogs.sh
@@ -8,7 +8,7 @@ debug_dialog() {
   # This function is for displaying commands run by the Configurator without actually running them
   # USAGE: debug_dialog "command"
 
-  zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
+  rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --title "RetroDECK Configurator Utility - Debug Dialog" \
   --text="$1"
@@ -17,7 +17,7 @@ debug_dialog() {
 configurator_process_complete_dialog() {
   # This dialog shows when a process is complete.
   # USAGE: configurator_process_complete_dialog "process text"
-  zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Quit" --extra-button="OK" \
+  rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Quit" --extra-button="OK" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --title "RetroDECK Configurator Utility - Process Complete" \
   --text="The process of $1 is now complete.\n\nYou may need to quit and restart RetroDECK for your changes to take effect\n\nClick OK to return to the Main Menu or Quit to quit RetroDECK."
@@ -33,7 +33,7 @@ configurator_generic_dialog() {
   # This dialog is for showing temporary messages before another process happens.
   # USAGE: configurator_generic_dialog "title text" "info text"
   log i "Showing a configurator_generic_dialog"
-  zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
+  rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --title "$1" \
   --text="$2"
@@ -43,7 +43,7 @@ configurator_generic_question_dialog() {
   # This dialog provides a generic dialog for getting a response from a user.
   # USAGE: $(configurator_generic_question_dialog "title text" "action text")
   # This function will return a "true" if the user clicks "Yes", and "false" if they click "No".
-  choice=$(zenity --title "RetroDECK - $1" --question --no-wrap --cancel-label="No" --ok-label="Yes" \
+  choice=$(rd_zenity --title "RetroDECK - $1" --question --no-wrap --cancel-label="No" --ok-label="Yes" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --text="$2")
   if [[ $? == "0" ]]; then
@@ -57,7 +57,7 @@ configurator_destination_choice_dialog() {
   # This dialog is for making things easy for new users to move files to common locations. Gives the options for "Internal", "SD Card" and "Custom" locations.
   # USAGE: $(configurator_destination_choice_dialog "folder being moved" "action text")
   # This function returns one of the values: "Back" "Internal Storage" "SD Card" "Custom Location"
-  choice=$(zenity --title "RetroDECK Configurator Utility - Moving $1 folder" --info --no-wrap --ok-label="Back" --extra-button="Internal Storage" --extra-button="SD Card" --extra-button="Custom Location" \
+  choice=$(rd_zenity --title "RetroDECK Configurator Utility - Moving $1 folder" --info --no-wrap --ok-label="Back" --extra-button="Internal Storage" --extra-button="SD Card" --extra-button="Custom Location" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --text="$2")
 
@@ -73,7 +73,7 @@ configurator_reset_confirmation_dialog() {
   # This dialog provides a confirmation for any reset functions, before the reset is actually performed.
   # USAGE: $(configurator_reset_confirmation_dialog "emulator being reset" "action text")
   # This function will return a "true" if the user clicks Confirm, and "false" if they click Cancel.
-  choice=$(zenity --title "RetroDECK Configurator Utility - Reset $1" --question --no-wrap --cancel-label="Cancel" --ok-label="Confirm" \
+  choice=$(rd_zenity --title "RetroDECK Configurator Utility - Reset $1" --question --no-wrap --cancel-label="Cancel" --ok-label="Confirm" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --text="$2")
   if [[ $? == "0" ]]; then
@@ -133,7 +133,7 @@ configurator_move_folder_dialog() {
               configurator_generic_dialog "RetroDECK Configurator - Move Folder" "The moving process was not completed, please try again."
             fi
           else # If there isn't enough space in the picked destination
-            zenity --icon-name=net.retrodeck.retrodeck --error --no-wrap \
+            rd_zenity --icon-name=net.retrodeck.retrodeck --error --no-wrap \
             --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
             --title "RetroDECK Configurator Utility - Move Directories" \
             --text="The destination directory you have selected does not have enough free space for the files you are trying to move.\n\nPlease select a new destination or free up some space."
@@ -170,7 +170,7 @@ changelog_dialog() {
   if [[ "$1" == "all" ]]; then
     xml sel -t -m "//release" -v "concat('RetroDECK version: ', @version)" -n -v "description" -n $rd_appdata | awk '{$1=$1;print}' | sed -e '/./b' -e :n -e 'N;s/\n$//;tn' > "/var/config/retrodeck/changelog.txt"
 
-    zenity --icon-name=net.retrodeck.retrodeck --text-info --width=1200 --height=720 \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --text-info --width=1200 --height=720 \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Changelogs" \
     --filename="/var/config/retrodeck/changelog.txt"
@@ -179,7 +179,7 @@ changelog_dialog() {
 
     echo -e "In RetroDECK version $1, the following changes were made:\n$version_changelog" > "/var/config/retrodeck/changelog-partial.txt" 2>/dev/null
 
-    zenity --icon-name=net.retrodeck.retrodeck --text-info --width=1200 --height=720 \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --text-info --width=1200 --height=720 \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Changelogs" \
     --filename="/var/config/retrodeck/changelog-partial.txt"
@@ -190,7 +190,7 @@ get_cheevos_token_dialog() {
   # This function will return a RetroAchvievements token from a valid username and password, will return "login failed" otherwise
   # USAGE: get_cheevos_token_dialog
 
-  local cheevos_info=$(zenity --forms --title="Cheevos" \
+  local cheevos_info=$(rd_zenity --forms --title="Cheevos" \
   --text="Username and password." \
   --separator="^" \
   --add-entry="Username" \
@@ -217,7 +217,7 @@ desktop_mode_warning() {
   if [[ $(check_desktop_mode) == "true" && $desktop_mode_warning == "true" ]]; then
     local message='You appear to be running RetroDECK in the Steam Deck'\''s Desktop mode!\n\nSome functions of RetroDECK may not work properly in Desktop mode, such as the Steam Deck'\''s normal controls.\n\nRetroDECK is best enjoyed in Game mode!\n\nDo you still want to proceed?'
     log i "Showing message:\n$message"
-    choice=$(zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="Never show this again" \
+    choice=$(rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="Never show this again" \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Desktop Mode Warning" \
     --text="$message")
@@ -245,7 +245,7 @@ low_space_warning() {
     if [[ "$used_percent" -ge 90 && -d "$HOME/retrodeck" ]]; then # If there is any RetroDECK data on the main drive to move
       local message='Your main drive is over 90% full!\n\nIf your drive fills completely this can lead to data loss or system crash.\n\nPlease consider moving some RetroDECK folders to other storage locations using the Configurator.'
       log i "Showing message:\n$message"
-      choice=$(zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="OK" --extra-button="Never show this again" \
+      choice=$(rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="OK" --extra-button="Never show this again" \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK Low Space Warning" \
       --text="$message")

--- a/functions/multi_user.sh
+++ b/functions/multi_user.sh
@@ -2,7 +2,7 @@
 
 multi_user_set_default_dialog() {
   chosen_user="$1"
-  choice=$(zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="No and don't ask again" \
+  choice=$(rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="No and don't ask again" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --title "RetroDECK Default User" \
   --text="Would you like to set $chosen_user as the default user?\n\nIf the current user cannot be determined from the system, the default will be used.\nThis normally only happens in Desktop Mode.\n\nIf you would like to be asked which user is playing every time, click \"No and don't ask again\"")
@@ -23,7 +23,7 @@ do
 full_userlist=("${full_userlist[@]}" "$user")
 done < <(ls -1 "$multi_user_data_folder")
 
-chosen_user=$(zenity \
+chosen_user=$(rd_zenity \
   --list --width=1200 --height=720 \
   --ok-label="Select User" \
   --text="Choose the current user:" \
@@ -65,7 +65,7 @@ multi_user_disable_multi_user_mode() {
     full_userlist=("${full_userlist[@]}" "$user")
     done < <(ls -1 "$multi_user_data_folder")
 
-    single_user=$(zenity \
+    single_user=$(rd_zenity \
       --list --width=1200 --height=720 \
       --ok-label="Select User" \
       --text="Choose the current user:" \
@@ -125,7 +125,7 @@ multi_user_determine_current_user() {
         multi_user_setup_new_user
       else # If running in Desktop mode for the first time
         configurator_generic_dialog "RetroDECK Multi-User Mode" "The current user could not be determined from the system and there is no existing userlist.\n\nPlease enter the Steam account username (not profile name) into the next dialog, or run RetroDECK in game mode."
-        if zenity --entry \
+        if rd_zenity --entry \
           --title="Specify Steam username" \
           --text="Enter Steam username:"
         then # User clicked "OK"

--- a/functions/other_functions.sh
+++ b/functions/other_functions.sh
@@ -285,6 +285,11 @@ dir_prep() {
   log i "$symlink is now $real"
 }
 
+rd_zenity() {
+  # This function replaces the standard 'zenity' command and filters out annoying GTK errors on Steam Deck
+  zenity 2> >(grep -v 'Gtk' >&2) "$@"
+}
+
 update_rpcs3_firmware() {
   create_dir "$roms_folder/ps3/tmp"
   chmod 777 "$roms_folder/ps3/tmp"

--- a/functions/other_functions.sh
+++ b/functions/other_functions.sh
@@ -8,10 +8,10 @@ directory_browse() {
 
   while [ $path_selected == false ]
   do
-    local target="$(zenity --file-selection --title="Choose $1" --directory)"
+    local target="$(rd_zenity --file-selection --title="Choose $1" --directory)"
     if [ ! -z "$target" ] #yes
     then
-      zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
+      rd_zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
       --text="Directory $target chosen, is this correct?"
       if [ $? == 0 ]
       then
@@ -20,7 +20,7 @@ directory_browse() {
         break
       fi
     else
-      zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
+      rd_zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
       --text="No directory selected. Do you want to exit the selection process?"
       if [ $? == 0 ]
       then
@@ -38,10 +38,10 @@ file_browse() {
 
   while [ $file_selected == false ]
   do
-    local target="$(zenity --file-selection --title="Choose $1")"
+    local target="$(rd_zenity --file-selection --title="Choose $1")"
     if [ ! -z "$target" ] #yes
     then
-      zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
+      rd_zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
       --text="File $target chosen, is this correct?"
       if [ $? == 0 ]
       then
@@ -50,7 +50,7 @@ file_browse() {
         break
       fi
     else
-      zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
+      rd_zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" \
       --text="No file selected. Do you want to exit the selection process?"
       if [ $? == 0 ]
       then
@@ -89,13 +89,13 @@ move() {
     rsync -a --remove-source-files --ignore-existing --mkpath "$source_dir" "$dest_dir" # Copy files but don't overwrite conflicts
     find "$source_dir" -type d -empty -delete # Cleanup empty folders that were left behind
   ) |
-  zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+  rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --title "RetroDECK Configurator Utility - Move in Progress" \
   --text="Moving directory $(basename "$1") to new location of $2, please wait."
 
   if [[ -d "$source_dir" ]]; then # Some conflicting files remain
-    zenity --icon-name=net.retrodeck.retrodeck --error --no-wrap \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --error --no-wrap \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator Utility - Move Directories" \
     --text="There were some conflicting files that were not moved.\n\nAll files that could be moved are in the new location,\nany files that already existed at the new location have not been moved and will need to be handled manually."
@@ -133,7 +133,7 @@ download_file() {
   (
     wget "$1" -O "$2" -q
   ) |
-  zenity --progress \
+  rd_zenity --progress \
     --title="Downloading File" \
     --text="Downloading $3..." \
     --pulsate \
@@ -327,10 +327,10 @@ finit_browse() {
 path_selected=false
 while [ $path_selected == false ]
 do
-  local target="$(zenity --file-selection --title="Choose RetroDECK data directory location" --directory)"
+  local target="$(rd_zenity --file-selection --title="Choose RetroDECK data directory location" --directory)"
   if [[ ! -z "$target" ]]; then
     if [[ -w "$target" ]]; then
-      zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" \
+      rd_zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" \
       --cancel-label="No" \
       --ok-label "Yes" \
       --text="Your RetroDECK data folder will be:\n\n$target/retrodeck\n\nis that ok?"
@@ -340,7 +340,7 @@ do
         echo "$target/retrodeck"
         break
       else
-        zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" --text="Do you want to quit?"
+        rd_zenity --question --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" --cancel-label="No" --ok-label "Yes" --text="Do you want to quit?"
         if [ $? == 0 ] # yes, quit
         then
           quit_retrodeck
@@ -348,7 +348,7 @@ do
       fi
     fi
   else
-    zenity --error --no-wrap \
+    rd_zenity --error --no-wrap \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK" \
     --ok-label "Quit" \
@@ -367,7 +367,7 @@ finit_user_options_dialog() {
   done < $finit_options_list
 
 
-  local choices=$(zenity \
+  local choices=$(rd_zenity \
   --list --width=1200 --height=720 \
   --checklist --hide-column=4 --ok-label="Confirm Selections" --extra-button="Enable All" \
   --separator=" " --print-column=4 \
@@ -411,7 +411,7 @@ finit() {
     if [ ! -d "$sdcard" ] # SD Card path is not existing
     then
       log e "SD card not found"
-      zenity --error --no-wrap \
+      rd_zenity --error --no-wrap \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK" \
       --ok-label "Browse" \
@@ -424,7 +424,7 @@ finit() {
     elif [ ! -w "$sdcard" ] #SD card found but not writable
       then
         log e "SD card found but not writable"
-        zenity --error --no-wrap \
+        rd_zenity --error --no-wrap \
         --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
         --title "RetroDECK" \
         --ok-label "Quit" \
@@ -439,7 +439,7 @@ finit() {
 
   "Custom Location" )
       log i "Custom Location selected"
-      zenity --info --no-wrap \
+      rd_zenity --info --no-wrap \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK" \
       --ok-label "Browse" \
@@ -470,7 +470,7 @@ finit() {
     configurator_generic_dialog "Vita3K Firmware Install" "You have chosen to install the Vita3K firmware during the RetroDECK first setup.\n\nThis process will take several minutes and requires network access.\n\nVita3K will be launched automatically at the end of the RetroDECK setup process.\nOnce the firmware is installed, please close the emulator to finish the process."
   fi
 
-  zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
+  rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --title "RetroDECK" \
   --text="RetroDECK will now install the needed files, which can take up to one minute.\nRetroDECK will start once the process is completed.\n\nPress OK to continue."
 
@@ -498,7 +498,7 @@ finit() {
   fi
 
   ) |
-  zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+  rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --title "RetroDECK Finishing Initialization" \
   --text="RetroDECK is finishing the initial setup process, please wait."
@@ -714,7 +714,7 @@ branch_selector() {
 
     # Display branches in a Zenity list dialog
     selected_branch=$(
-      zenity --list \
+      rd_zenity --list \
         --icon-name=net.retrodeck.retrodeck \
         --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
         --title "RetroDECK Configurator Cooker Branch - Select Branch" \
@@ -724,7 +724,7 @@ branch_selector() {
 
     # Display warning message
     if [ $selected_branch ]; then
-        zenity --question --icon-name=net.retrodeck.retrodeck --no-wrap \
+        rd_zenity --question --icon-name=net.retrodeck.retrodeck --no-wrap \
           --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
           --title "RetroDECK Configurator Cooker Branch - Switch Branch" \
           --text="Are you sure you want to move to \"$selected_branch\" branch?"
@@ -745,7 +745,7 @@ branch_selector() {
           flatpak-spawn --host flatpak install --user --bundle --noninteractive -y "$rdhome/RetroDECK_Updates/RetroDECK-cooker.flatpak"
           rm -rf "$rdhome/RetroDECK_Updates" # Cleanup old bundles to save space
           ) |
-          zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+          rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
           --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
           --title "RetroDECK Updater" \
           --text="RetroDECK is updating to the latest \"$selected_branch\" version, please wait."

--- a/functions/post_update.sh
+++ b/functions/post_update.sh
@@ -380,7 +380,7 @@ post_update() {
   deploy_helper_files
   build_retrodeck_current_presets
   ) |
-  zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+  rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --title "RetroDECK - Upgrade Process" \
   --width=400 --height=200 \

--- a/functions/presets.sh
+++ b/functions/presets.sh
@@ -6,7 +6,7 @@ change_preset_dialog() {
 
   build_preset_list_options "$1"
 
-  choice=$(zenity \
+  choice=$(rd_zenity \
     --list --width=1200 --height=720 \
     --checklist \
     --separator="," \
@@ -23,7 +23,7 @@ change_preset_dialog() {
     (
       make_preset_changes
     ) |
-    zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator Utility - Presets Configuration" \
     --text="Setting up your presets, please wait..."

--- a/retrodeck.sh
+++ b/retrodeck.sh
@@ -113,7 +113,7 @@ if [ -f "$lockfile" ]; then
       set_setting_value $rd_conf "update_check" "true" retrodeck "options"
       set_setting_value $rd_conf "developer_options" "true" retrodeck "options"
       cooker_base_version=$(echo $hard_version | cut -d'-' -f2)
-      choice=$(zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Upgrade" --extra-button="Don't Upgrade" --extra-button="Full Wipe and Fresh Install" \
+      choice=$(rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Upgrade" --extra-button="Don't Upgrade" --extra-button="Full Wipe and Fresh Install" \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK Cooker Upgrade" \
       --text="You appear to be upgrading to a \"cooker\" build of RetroDECK.\n\nWould you like to perform the standard post-update process, skip the post-update process or remove ALL existing RetroDECK folders and data (including ROMs and saves) to start from a fresh install?\n\nPerforming the normal post-update process multiple times may lead to unexpected results.")

--- a/tools/configurator.sh
+++ b/tools/configurator.sh
@@ -124,7 +124,7 @@ configurator_welcome_dialog() {
     "RetroDECK: About" "Show additional information about RetroDECK")
   fi
 
-  choice=$(zenity --list --title="RetroDECK Configurator Utility" --cancel-label="Quit" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility" --cancel-label="Quit" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "${welcome_menu_options[@]}")
@@ -171,7 +171,7 @@ configurator_welcome_dialog() {
 }
 
 configurator_presets_and_settings_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - Presets & Settings" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - Presets & Settings" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "Global: Presets & Settings" "Here you find presets and settings that that span over multiple emulators" \
@@ -204,7 +204,7 @@ configurator_presets_and_settings_dialog() {
 }
 
 configurator_global_presets_and_settings_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - Global: Presets & Settings" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - Global: Presets & Settings" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "Widescreen: Enable/Disable" "Enable or disable widescreen in supported systems" \
@@ -287,7 +287,7 @@ configurator_global_presets_and_settings_dialog() {
 }
 
 configurator_retroarch_presets_and_settings_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - RetroArch: Presets & Settings" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - RetroArch: Presets & Settings" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "Borders: Enable/Disable" "Enable or disable borders in supported systems" )
@@ -309,7 +309,7 @@ configurator_retroarch_presets_and_settings_dialog() {
 }
 
 configurator_wii_and_gamecube_presets_and_settings_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - Wii & GameCube: Presets & Settings" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - Wii & GameCube: Presets & Settings" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "Dolphin Textures: Universal Dynamic Input" "Enable/Disable Venomalia's Universal Dynamic Input Textures for Dolphin" \
@@ -337,7 +337,7 @@ configurator_wii_and_gamecube_presets_and_settings_dialog() {
 
 configurator_dolphin_input_textures_dialog() {
   if [[ -d "/var/data/dolphin-emu/Load/DynamicInputTextures" ]]; then
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - Dolphin Textures: Universal Dynamic Input" \
     --text="Custom input textures are currently enabled. Do you want to disable them?"
@@ -351,7 +351,7 @@ configurator_dolphin_input_textures_dialog() {
       configurator_wii_and_gamecube_presets_and_settings_dialog
     fi
   else
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - Dolphin Textures: Universal Dynamic Input" \
     --text="Custom input textures are currently disabled. Do you want to enable them?\n\nThis process may take several minutes to complete."
@@ -363,7 +363,7 @@ configurator_dolphin_input_textures_dialog() {
         mkdir "/var/data/dolphin-emu/Load/DynamicInputTextures"
         rsync -rlD --mkpath "/app/retrodeck/extras/DynamicInputTextures/" "/var/data/dolphin-emu/Load/DynamicInputTextures/"
       ) |
-      zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+      rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK Configurator Utility - Dolphin Custom Input Textures Install"
       configurator_process_complete_dialog "enabling Dolphin custom input textures"
@@ -375,7 +375,7 @@ configurator_dolphin_input_textures_dialog() {
 
 configurator_primehack_input_textures_dialog() {
   if [[ -d "/var/data/primehack/Load/DynamicInputTextures" ]]; then
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - Dolphin Custom Input Textures" \
     --text="Custom input textures are currently enabled. Do you want to disable them?"
@@ -389,7 +389,7 @@ configurator_primehack_input_textures_dialog() {
       configurator_wii_and_gamecube_presets_and_settings_dialog
     fi
   else
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - Primehack Custom Input Textures" \
     --text="Custom input textures are currently disabled. Do you want to enable them?\n\nThis process may take several minutes to complete."
@@ -401,7 +401,7 @@ configurator_primehack_input_textures_dialog() {
         mkdir "/var/data/primehack/Load/DynamicInputTextures"
         rsync -rlD --mkpath "/app/retrodeck/extras/DynamicInputTextures/" "/var/data/primehack/Load/DynamicInputTextures/"
       ) |
-      zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+      rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK Configurator Utility - Primehack Custom Input Textures Install"
       configurator_process_complete_dialog "enabling Primehack custom input textures"
@@ -413,7 +413,7 @@ configurator_primehack_input_textures_dialog() {
 
 configurator_power_user_warning_dialog() {
   if [[ $power_user_warning == "true" ]]; then
-    choice=$(zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="Never show this again" \
+    choice=$(rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap --ok-label="Yes" --extra-button="No" --extra-button="Never show this again" \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Power User Warning" \
     --text="Making manual changes to an emulator's configuration may create serious issues,\nand some settings may be overwitten during RetroDECK updates or when using presets.\n\nSome standalone emulator functions may not work properly outside of Desktop mode.\n\nPlease continue only if you know what you're doing.\n\nDo you want to continue?")
@@ -457,7 +457,7 @@ configurator_open_emulator_dialog() {
     emulator_list+=("Citra" "Open the 3DS emulator Citra")
   fi
 
-  emulator=$(zenity --list \
+  emulator=$(rd_zenity --list \
   --title "RetroDECK Configurator Utility - Open Emulator" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --text="Which emulator do you want to launch?" \
@@ -572,7 +572,7 @@ configurator_retrodeck_tools_dialog() {
     choices+=("Ponzu - Remove Citra" "Run Ponzu to remove Citra from RetroDECK. Configurations and saves will be mantained.")
   fi
 
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Tools" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Tools" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "${choices[@]}")
@@ -591,7 +591,7 @@ configurator_retrodeck_tools_dialog() {
     configurator_generic_dialog "RetroDECK Configurator - Remove Empty ROM Folders" "Searching for empty rom folders, please be patient..."
     find_empty_rom_folders
 
-    choice=$(zenity \
+    choice=$(rd_zenity \
         --list --width=1200 --height=720 --title "RetroDECK Configurator - RetroDECK: Remove Empty ROM Folders" \
         --checklist --hide-column=3 --ok-label="Remove Selected" --extra-button="Remove All" \
         --separator="," --print-column=2 \
@@ -649,7 +649,7 @@ configurator_retrodeck_tools_dialog() {
       (
         update_rpcs3_firmware
       ) |
-        zenity --progress --no-cancel --pulsate --auto-close \
+        rd_zenity --progress --no-cancel --pulsate --auto-close \
         --icon-name=net.retrodeck.retrodeck \
         --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
         --title="Downloading PS3 Firmware" \
@@ -668,7 +668,7 @@ configurator_retrodeck_tools_dialog() {
       (
         update_vita3k_firmware
       ) |
-        zenity --progress --pulsate \
+        rd_zenity --progress --pulsate \
         --icon-name=net.retrodeck.retrodeck \
         --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
         --title="Downloading PS Vita Firmware" \
@@ -702,7 +702,7 @@ configurator_retrodeck_tools_dialog() {
 }
 
 configurator_retrodeck_move_tool_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Move Tool" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Move Tool" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "Move all of RetroDECK" "Move the entire retrodeck folder to a new location" \
@@ -774,7 +774,7 @@ configurator_retrodeck_move_tool_dialog() {
 }
 
 configurator_compression_tool_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Compression Tool" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Compression Tool" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "Compress Single Game" "Compress a single game into a compatible format" \
@@ -836,7 +836,7 @@ configurator_compress_single_game_dialog() {
       log i "Compressing $(basename "$file") to $compatible_compression_format format"
       compress_game "$compatible_compression_format" "$file" "$system"
       ) |
-      zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+      rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK Configurator Utility - Compression in Progress"
       configurator_generic_dialog "RetroDECK Configurator - RetroDECK: Compression Tool" "The compression process is complete."
@@ -858,7 +858,7 @@ configurator_compress_multiple_games_dialog() {
 
   if [[ ! $(echo "${#all_compressable_games[@]}") == "0" ]]; then
     if [[ ! "$target_selection" == "everything" ]]; then # If the user chose to not auto-compress everything
-      choice=$(zenity \
+      choice=$(rd_zenity \
           --list --width=1200 --height=720 --title "RetroDECK Configurator - RetroDECK: Compression Tool" \
           --checklist --hide-column=3 --ok-label="Compress Selected" --extra-button="Compress All" \
           --separator="," --print-column=3 \
@@ -902,7 +902,7 @@ configurator_compress_multiple_games_dialog() {
       compress_game "$compression_format" "$file" "$system"
     done
     ) |
-    zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --auto-close \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --auto-close \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK Configurator Utility - Compression in Progress"
       configurator_generic_dialog "RetroDECK Configurator - RetroDECK: Compression Tool" "The compression process is complete!"
@@ -913,7 +913,7 @@ configurator_compress_multiple_games_dialog() {
 }
 
 configurator_compression_cleanup_dialog() {
-  zenity --icon-name=net.retrodeck.retrodeck --question --no-wrap --cancel-label="No" --ok-label="Yes" \
+  rd_zenity --icon-name=net.retrodeck.retrodeck --question --no-wrap --cancel-label="No" --ok-label="Yes" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
   --title "RetroDECK Configurator - RetroDECK: Compression Tool" \
   --text="Do you want to remove old files after they are compressed?\n\nClicking \"No\" will leave all files behind which will need to be cleaned up manually and may result in game duplicates showing in the RetroDECK library.\n\nPlease make sure you have a backup of your ROMs before using automatic cleanup!"
@@ -927,7 +927,7 @@ configurator_compression_cleanup_dialog() {
 
 configurator_online_update_setting_dialog() {
   if [[ $(get_setting_value $rd_conf "update_check" retrodeck "options") == "true" ]]; then
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - RetroDECK Online Update Check" \
     --text="Online update checks for RetroDECK are currently enabled.\n\nDo you want to disable them?"
@@ -939,7 +939,7 @@ configurator_online_update_setting_dialog() {
       configurator_retrodeck_tools_dialog
     fi
   else
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - RetroDECK Online Update Check" \
     --text="Online update checks for RetroDECK are currently disabled.\n\nDo you want to enable them?"
@@ -954,7 +954,7 @@ configurator_online_update_setting_dialog() {
 }
 
 configurator_retrodeck_troubleshooting_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Troubleshooting" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Troubleshooting" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "Backup: RetroDECK Userdata" "Compress and backup important RetroDECK user data folders" \
@@ -971,7 +971,7 @@ configurator_retrodeck_troubleshooting_dialog() {
     (
       backup_retrodeck_userdata
     ) |
-    zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
             --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
             --title "RetroDECK Configurator Utility - Backup in Progress" \
             --text="Backing up RetroDECK userdata, please wait..."
@@ -1016,7 +1016,7 @@ configurator_check_bios_files() {
 
   check_bios_files "basic"
 
-  zenity --list --title="RetroDECK Configurator Utility - Check & Verify: BIOS Files" --cancel-label="Back" \
+  rd_zenity --list --title="RetroDECK Configurator Utility - Check & Verify: BIOS Files" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column "BIOS File Name" \
   --column "System" \
@@ -1034,7 +1034,7 @@ configurator_check_bios_files_expert_mode() {
 
   check_bios_files "expert"
 
-  zenity --list --title="RetroDECK Configurator Utility - Check & Verify: BIOS Files" --cancel-label="Back" \
+  rd_zenity --list --title="RetroDECK Configurator Utility - Check & Verify: BIOS Files" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column "BIOS File Name" \
   --column "System" \
@@ -1052,7 +1052,7 @@ configurator_check_multifile_game_structure() {
   local folder_games=($(find $roms_folder -maxdepth 2 -mindepth 2 -type d ! -name "*.m3u" ! -name "*.ps3"))
   if [[ ${#folder_games[@]} -gt 1 ]]; then
     echo "$(find $roms_folder -maxdepth 2 -mindepth 2 -type d ! -name "*.m3u" ! -name "*.ps3")" > $logs_folder/multi_file_games_"$(date +"%Y_%m_%d_%I_%M_%p").log"
-    zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - Check & Verify: Multi-file structure" \
     --text="The following games were found to have the incorrect folder structure:\n\n$(find $roms_folder -maxdepth 2 -mindepth 2 -type d ! -name "*.m3u" ! -name "*.ps3")\n\nIncorrect folder structure can result in failure to launch games or saves being in the incorrect location.\n\nPlease see the RetroDECK wiki for more details!\n\nYou can find this list of games in ~/retrodeck/logs"
@@ -1071,7 +1071,7 @@ configurator_reset_dialog() {
     "Reset RetroDECK" "Reset RetroDECK to default settings"
   )
 
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Reset" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - RetroDECK: Reset" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Action" \
   "${choices[@]}")
@@ -1105,7 +1105,7 @@ configurator_reset_dialog() {
 
   "Reset Emulator or Engine" )
     log i "Configurator: opening \"$choice\" menu"
-    component_to_reset=$(zenity --list \
+    component_to_reset=$(rd_zenity --list \
     --title "RetroDECK Configurator Utility - Reset Specific Standalone Emulator" --cancel-label="Back" \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
     --text="Which emulator or engine do you want to reset to default?" \
@@ -1147,7 +1147,7 @@ configurator_reset_dialog() {
   ;;
 
   "Reset RetroDECK Component" )
-    component_to_reset=$(zenity --list \
+    component_to_reset=$(rd_zenity --list \
     --title "RetroDECK Configurator Utility - Reset Specific RetroDECK Component" --cancel-label="Back" \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
     --text="Which component do you want to reset to default settings?" \
@@ -1181,7 +1181,7 @@ configurator_reset_dialog() {
       (
       prepare_component "reset" "all"
       ) |
-      zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
+      rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --pulsate --auto-close \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
       --title "RetroDECK Finishing Initialization" \
       --text="RetroDECK is finishing the reset process, please wait."
@@ -1199,7 +1199,7 @@ configurator_reset_dialog() {
 "Reset RetroDECK" )
   log i "Configurator: opening \"$choice\" menu"
   if [[ $(configurator_reset_confirmation_dialog "RetroDECK" "Are you sure you want to reset RetroDECK entirely?\n\nThis process cannot be undone.") == "true" ]]; then
-    zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --info --no-wrap \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator Utility - Reset RetroDECK" \
     --text="You are resetting RetroDECK to its default state.\n\nAfter the process is complete you will need to exit RetroDECK and run it again, where you will go through the initial setup process."
@@ -1220,7 +1220,7 @@ configurator_reset_dialog() {
 }
 
 configurator_about_retrodeck_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - RetroDECK: About" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - RetroDECK: About" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Description" \
   "Version History" "View the version changelogs for RetroDECK" \
@@ -1235,7 +1235,7 @@ configurator_about_retrodeck_dialog() {
 
   "Credits" )
     log i "Configurator: opening \"$choice\" menu"
-    zenity --icon-name=net.retrodeck.retrodeck --text-info --width=1200 --height=720 \
+    rd_zenity --icon-name=net.retrodeck.retrodeck --text-info --width=1200 --height=720 \
     --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Credits" \
     --filename="$emuconfigs/defaults/retrodeck/reference_lists/retrodeck_credits.txt"
@@ -1258,7 +1258,7 @@ configurator_version_history_dialog() {
     all_versions_list=("${all_versions_list[@]}" "RetroDECK $rd_version Changelog" "View the changes specific to version $rd_version")
   done
 
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - RetroDECK Version History" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - RetroDECK Version History" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Description" \
   "Full RetroDECK Changelog" "View the list of all changes that have ever been made to RetroDECK" \
@@ -1283,7 +1283,7 @@ configurator_version_history_dialog() {
 }
 
 configurator_developer_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - Developer Options" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - Developer Options" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Description" \
   "Change Multi-user mode" "Enable or disable multi-user support" \
@@ -1332,7 +1332,7 @@ configurator_developer_dialog() {
 
 configurator_retrodeck_multiuser_dialog() {
   if [[ $(get_setting_value $rd_conf "multi_user_mode" retrodeck "options") == "true" ]]; then
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - RetroDECK Multi-user Support" \
     --text="Multi-user support is currently enabled. Do you want to disable it?\n\nIf there is more than one user configured,\nyou will be given a choice of which to use as the single RetroDECK user.\n\nThis user's files will be moved to the default locations.\n\nOther users' files will remain in the mutli-user-data folder.\n"
@@ -1344,7 +1344,7 @@ configurator_retrodeck_multiuser_dialog() {
       configurator_developer_dialog
     fi
   else
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - RetroDECK Multi-user support" \
     --text="Multi-user support is currently disabled. Do you want to enable it?\n\nThe current user's saves and states will be backed up and then moved to the \"retrodeck/multi-user-data\" folder.\nAdditional users will automatically be stored in their own folder here as they are added."
@@ -1360,7 +1360,7 @@ configurator_retrodeck_multiuser_dialog() {
 
 configurator_online_update_channel_dialog() {
   if [[ $(get_setting_value $rd_conf "update_repo" retrodeck "options") == "RetroDECK" ]]; then
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - RetroDECK Change Update Branch" \
     --text="You are currently on the production branch of RetroDECK updates. Would you like to switch to the cooker branch?\n\nAfter installing a cooker build, you may need to remove the \"stable\" branch install of RetroDECK to avoid overlap."
@@ -1372,7 +1372,7 @@ configurator_online_update_channel_dialog() {
       configurator_developer_dialog
     fi
   else
-    zenity --question \
+    rd_zenity --question \
     --no-wrap --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
     --title "RetroDECK Configurator - RetroDECK Change Update Branch" \
     --text="You are currently on the cooker branch of RetroDECK updates. Would you like to switch to the production branch?\n\nAfter installing a production build, you may need to remove the \"cooker\" branch install of RetroDECK to avoid overlap."
@@ -1387,7 +1387,7 @@ configurator_online_update_channel_dialog() {
 }
 
 configurator_usb_import_dialog() {
-  choice=$(zenity --list --title="RetroDECK Configurator Utility - Developer Options" --cancel-label="Back" \
+  choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - Developer Options" --cancel-label="Back" \
   --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
   --column="Choice" --column="Description" \
   "Prepare USB device" "Create ROM folders on a selected USB device" \
@@ -1405,7 +1405,7 @@ configurator_usb_import_dialog() {
     done < <(df --output=size,target | grep media | grep -v $default_sd | awk '{$1=$1;print}')
 
     if [[ "${#external_devices[@]}" -gt 0 ]]; then
-      choice=$(zenity --list --title="RetroDECK Configurator Utility - USB Migration Tool" --cancel-label="Back" \
+      choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - USB Migration Tool" --cancel-label="Back" \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
       --hide-column=3 --print-column=3 \
       --column "Device Name" \
@@ -1435,7 +1435,7 @@ configurator_usb_import_dialog() {
     done < <(df --output=size,target | grep media | grep -v $default_sd | awk '{$1=$1;print}')
 
     if [[ "${#external_devices[@]}" -gt 0 ]]; then
-      choice=$(zenity --list --title="RetroDECK Configurator Utility - USB Migration Tool" --cancel-label="Back" \
+      choice=$(rd_zenity --list --title="RetroDECK Configurator Utility - USB Migration Tool" --cancel-label="Back" \
       --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" --width=1200 --height=720 \
       --hide-column=3 --print-column=3 \
       --column "Device Name" \
@@ -1449,7 +1449,7 @@ configurator_usb_import_dialog() {
             (
             rsync -a --mkpath "$choice/ROMs/"* "$roms_folder"
             ) |
-            zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --auto-close \
+            rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --auto-close \
             --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
             --title "RetroDECK Configurator Utility - USB Import In Progress"
             configurator_generic_dialog "RetroDECK Configurator - USB Migration Tool" "The import process is complete!"
@@ -1458,7 +1458,7 @@ configurator_usb_import_dialog() {
           (
           rsync -a --mkpath "$choice/ROMs/"* "$roms_folder"
           ) |
-          zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --auto-close \
+          rd_zenity --icon-name=net.retrodeck.retrodeck --progress --no-cancel --auto-close \
           --window-icon="/app/share/icons/hicolor/scalable/apps/net.retrodeck.retrodeck.svg" \
           --title "RetroDECK Configurator Utility - USB Import In Progress"
           configurator_generic_dialog "RetroDECK Configurator - USB Migration Tool" "The import process is complete!"


### PR DESCRIPTION
Replace standard zenity commands with a filter function that keeps useless Gtk-related errors from cluttering up the terminal