### PR TITLE
Change 'Full_Press' to 'Long_Press' in controller config for preset switch

### DIFF
--- a/config/retrodeck/controller_configs/RetroDECK_controller_generic_standard_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_generic_standard_simple.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"160"
-	"title"		"RetroDECK: Generic - Standard v.1b"
-	"description"		"RetroDECK: Generic - Standard - v.1b"
+	"title"		"RetroDECK: Generic - Standard v.2b"
+	"description"		"RetroDECK: Generic - Standard - v.2b"
 	"creator"		""
 	"progenitor"		""
 	"url"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_ps3_dualshock3_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_ps3_dualshock3_simple.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"93"
-	"title"		"RetroDECK: DualShock 3 v.1b"
-	"description"		"RetroDECK: PS3 - DualShock 3 - v.1b"
+	"title"		"RetroDECK: DualShock 3 v.2b"
+	"description"		"RetroDECK: PS3 - DualShock 3 - v.2b"
 	"creator"		""
 	"progenitor"		""
 	"url"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_ps4_dualshock4_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_ps4_dualshock4_simple.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"81"
-	"title"		"RetroDECK: DualShock 4 v.1b"
-	"description"		"RetroDECK: PS4 - DualShock 4 - v.1b"
+	"title"		"RetroDECK: DualShock 4 v.2b"
+	"description"		"RetroDECK: PS4 - DualShock 4 - v.2b"
 	"creator"		""
 	"progenitor"		""
 	"url"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_ps5_dualsense_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_ps5_dualsense_simple.vdf
@@ -2,7 +2,7 @@
 {
 	"version"		"3"
 	"revision"		"114"
-	"title"		"RetroDECK: DualSense v.1b"
+	"title"		"RetroDECK: DualSense v.2b"
 	"description"		"RetroDECK: PS5 - DualSense v.1"
 	"creator"		""
 	"progenitor"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_steam_controller_gordon_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_steam_controller_gordon_simple.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"73"
-	"title"		"RetroDECK: Steam Controller - Gordon v.1b"
-	"description"		"RetroDECK: Steam Controller - Gordon v.1b"
+	"title"		"RetroDECK: Steam Controller - Gordon v.2b"
+	"description"		"RetroDECK: Steam Controller - Gordon v.2b"
 	"creator"		""
 	"progenitor"		""
 	"url"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_steamdeck_neptune_full.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_steamdeck_neptune_full.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"1864"
-	"title"		"RetroDECK: Steam Deck - Neptune v.1.1b FULL"
-	"description"		"RetroDECK: Steam Deck - Neptune v.1.1b FULL"
+	"title"		"RetroDECK: Steam Deck - Neptune v.2.1b FULL"
+	"description"		"RetroDECK: Steam Deck - Neptune v.2.1b FULL"
 	"creator"		""
 	"progenitor"		""
 	"url"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_steamdeck_neptune_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_steamdeck_neptune_simple.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"1874"
-	"title"		"RetroDECK: Steam Deck - Neptune v.1b SIMPLE"
-	"description"		"RetroDECK: Steam Deck - Neptune v.1b SIMPLE"
+	"title"		"RetroDECK: Steam Deck - Neptune v.2b SIMPLE"
+	"description"		"RetroDECK: Steam Deck - Neptune v.2b SIMPLE"
 	"creator"		""
 	"progenitor"		""
 	"url"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_switch_pro_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_switch_pro_simple.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"83"
-	"title"		"RetroDECK: Switch Pro v.1b"
-	"description"		"RetroDECK: Switch - Pro Controller - v.1b"
+	"title"		"RetroDECK: Switch Pro v.2b"
+	"description"		"RetroDECK: Switch - Pro Controller - v.2b"
 	"creator"		""
 	"progenitor"		""
 	"url"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_xbox360_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_xbox360_simple.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"84"
-	"title"		"RetroDECK: Xbox 360 v.1b"
-	"description"		"RetroDECK: Xbox 360 - v.1b"
+	"title"		"RetroDECK: Xbox 360 v.2b"
+	"description"		"RetroDECK: Xbox 360 - v.2b"
 	"creator"		""
 	"progenitor"		""
 	"url"		""

--- a/config/retrodeck/controller_configs/RetroDECK_controller_xboxone_simple.vdf
+++ b/config/retrodeck/controller_configs/RetroDECK_controller_xboxone_simple.vdf
@@ -2,8 +2,8 @@
 {
 	"version"		"3"
 	"revision"		"101"
-	"title"		"RetroDECK: Xbox Wireless v.1b"
-	"description"		"RetroDECK: One/S/X - Xbox Wireless v.1b"
+	"title"		"RetroDECK: Xbox Wireless v.2b"
+	"description"		"RetroDECK: One/S/X - Xbox Wireless v.2b"
 	"creator"		""
 	"progenitor"		""
 	"url"		""


### PR DESCRIPTION
Some games have situations in which you need to or might press SELECT in combination with another button (Final Fantasy 2: SELECT + CIRCLE to open map, Ace Combat 5: SELECT switches ammunition type, might want to do while controlling your plane with L1/L2/R1/R2). This can lead to frustrating experiences where you accidentally take a screenshot or worse load a save state.

In order to prevent accidentally executing a Hot Key, switching the controller preset to the Hot Key preset should be done on a long press of the SELECT button instead.