### PR TITLE
Follow symlinks when looking for BIOS files

### DIFF
--- a/functions/api_data_processing.sh
+++ b/functions/api_data_processing.sh
@@ -315,7 +315,7 @@ api_get_bios_file_status() {
   merged_bios_info=$(echo "$merged_bios_info" | envsubst)
 
   # Find all files in the base BIOS directory as well as any specified extra paths in the BIOS reference file
-  mapfile -t files_to_check < <( { echo "$merged_bios_info" | jq -r --argjson systems "$systems_to_check" 'if ($systems | length) == 0 then [.bios[] | select(has("paths")) | .paths] else [.bios[] | select(has("paths") and ([.system] | flatten | any(. as $s | $systems | index($s)))) | .paths] end | flatten | unique | .[]'; echo "$bios_path"; } | xargs -I {} sh -c '[ -d "{}" ] && find "{}" -maxdepth 1 -type f -not -iname ".directory" -not -iname "*.txt"')
+  mapfile -t files_to_check < <( { echo "$merged_bios_info" | jq -r --argjson systems "$systems_to_check" 'if ($systems | length) == 0 then [.bios[] | select(has("paths")) | .paths] else [.bios[] | select(has("paths") and ([.system] | flatten | any(. as $s | $systems | index($s)))) | .paths] end | flatten | unique | .[]'; echo "$bios_path"; } | xargs -I {} sh -c '[ -d "{}" ] && find -L "{}" -maxdepth 1 -type f -not -iname ".directory" -not -iname "*.txt"')
 
   # Create a lookup array of all found filenames and their found paths
   declare -A found_file_lookup


### PR DESCRIPTION
This adds `-L` to the `find` command when looking for BIOS files, telling it to follow symbolic links.

I store my BIOS files in folders separated by system, and use symbolic links to create the mapping expected by various emulators/tools (e.g. `ps1_rom.bin` pointing to `psx/ps1_rom.bin`).
With my setup, the BIOS Checker tool is ignoring most of my files even though they're at the right location since the script is only looking for regular files.